### PR TITLE
feat: add monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,29 @@ both the `kind-k8s-eu` and `kind-k8s-us` clusters.
 Ensure that you have the latest version of the `cnpg` plugin installed on your
 local machine.
 
+## Monitoring with Prometheus and Grafana
+
+The playground also includes an optional setup for evaluating Prometheus
+metrics and visualizing them with Grafana. To deploy both Prometheus and
+Grafana on the infrastructure node, run the following command:
+
+```bash
+./scripts/monitoring-setup.sh
+```
+
+To access Grafana from your local browser, open a terminal and forward the
+necessary ports locally. For example, use the following commands to forward
+ports for the EU and US environments:
+
+```bash
+kubectl --context=kind-k8s-eu port-forward -n grafana service/grafana-service 3000:3000
+kubectl --context=kind-k8s-us port-forward -n grafana service/grafana-service 3001:3000
+```
+
+This will make Grafana accessible on your local machine at
+`http://localhost:3000` for the EU environment and `http://localhost:3001` for
+the US environment.
+
 ## Cleaning up the Learning Environment
 
 When you're ready to clean up and remove all resources from the learning

--- a/README.md
+++ b/README.md
@@ -162,8 +162,10 @@ necessary ports locally. For example, use the following commands to forward
 ports for the EU and US environments:
 
 ```bash
-kubectl --context=kind-k8s-eu port-forward -n grafana service/grafana-service 3000:3000
-kubectl --context=kind-k8s-us port-forward -n grafana service/grafana-service 3001:3000
+kubectl --context=kind-k8s-eu port-forward -n grafana \
+  service/grafana-service 3000:3000
+kubectl --context=kind-k8s-us port-forward -n grafana \
+  service/grafana-service 3001:3000
 ```
 
 This will make Grafana accessible on your local machine at

--- a/demo/yaml/eu/pg-eu.yaml
+++ b/demo/yaml/eu/pg-eu.yaml
@@ -68,6 +68,9 @@ spec:
       parameters:
         barmanObjectName: minio-us
         serverName: pg-us
+
+  monitoring:
+    enablePodMonitor: true
 ---
 # See https://cloudnative-pg.io/documentation/current/backup/#scheduled-backups
 apiVersion: postgresql.cnpg.io/v1

--- a/demo/yaml/us/pg-us.yaml
+++ b/demo/yaml/us/pg-us.yaml
@@ -82,6 +82,9 @@ spec:
       parameters:
         barmanObjectName: minio-us
         serverName: pg-us
+
+  monitoring:
+    enablePodMonitor: true
 ---
 # See https://cloudnative-pg.io/documentation/current/backup/#scheduled-backups
 apiVersion: postgresql.cnpg.io/v1

--- a/k8s/monitoring/grafana/grafana_dashboard.yaml
+++ b/k8s/monitoring/grafana/grafana_dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cloudnativepg-dashboard
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  url: "https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/refs/heads/main/charts/cluster/grafana-dashboard.json"

--- a/k8s/monitoring/grafana/grafana_datasource.yaml
+++ b/k8s/monitoring/grafana/grafana_datasource.yaml
@@ -1,0 +1,19 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: prometheus
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  allowCrossNamespaceImport: true
+  datasource:
+    access: proxy
+    database: prometheus
+    jsonData:
+      timeInterval: 5s
+      tlsSkipVerify: true
+    name: DS_PROMETHEUS
+    type: prometheus
+    url: http://prometheus-operated.prometheus-operator.svc.cluster.local:9090

--- a/k8s/monitoring/grafana/grafana_instance.yaml
+++ b/k8s/monitoring/grafana/grafana_instance.yaml
@@ -1,0 +1,13 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  config:
+    log:
+      mode: "console"
+    security:
+      admin_user: admin
+      admin_password: admin

--- a/k8s/monitoring/grafana/grafana_instance.yaml
+++ b/k8s/monitoring/grafana/grafana_instance.yaml
@@ -11,3 +11,9 @@ spec:
     security:
       admin_user: admin
       admin_password: admin
+  deployment:
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            node-role.kubernetes.io/infra: ""

--- a/k8s/monitoring/grafana/kustomization.yaml
+++ b/k8s/monitoring/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - grafana_instance.yaml
+ - grafana_datasource.yaml
+ - grafana_dashboard.yaml
+namespace: grafana

--- a/k8s/monitoring/prometheus-instance/deploy_prometheus.yaml
+++ b/k8s/monitoring/prometheus-instance/deploy_prometheus.yaml
@@ -55,3 +55,5 @@ spec:
   serviceAccountName: prometheus
   podMonitorSelector: {}
   podMonitorNamespaceSelector: {}
+  nodeSelector:
+    node-role.kubernetes.io/infra: ""

--- a/k8s/monitoring/prometheus-instance/deploy_prometheus.yaml
+++ b/k8s/monitoring/prometheus-instance/deploy_prometheus.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+spec:
+  serviceAccountName: prometheus
+  podMonitorSelector: {}
+  podMonitorNamespaceSelector: {}

--- a/k8s/monitoring/prometheus-instance/kustomization.yaml
+++ b/k8s/monitoring/prometheus-instance/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - deploy_prometheus.yaml
+namespace: prometheus-operator

--- a/k8s/monitoring/prometheus-operator/kustomization.yaml
+++ b/k8s/monitoring/prometheus-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - https://github.com/prometheus-operator/prometheus-operator/
+namespace: prometheus-operator

--- a/scripts/monitoring-setup.sh
+++ b/scripts/monitoring-setup.sh
@@ -49,3 +49,7 @@ for context in kind-k8s-eu kind-k8s-us; do
     kubectl kustomize ${git_repo_root}/k8s/monitoring/grafana/ | \
     kubectl --context $context apply -f -
 done
+
+# Restart the operator
+kubectl rollout restart deployment -n cnpg-system cnpg-controller-manager
+kubectl rollout status deployment -n cnpg-system cnpg-controller-manager

--- a/scripts/monitoring-setup.sh
+++ b/scripts/monitoring-setup.sh
@@ -46,7 +46,6 @@ for context in kind-k8s-eu kind-k8s-us; do
             patch deployment grafana-operator-controller-manager \
             --type='merge' --patch='{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/infra","operator":"Exists","effect":"NoSchedule"}],"nodeSelector":{"node-role.kubernetes.io/infra":""}}}}}'
 done
-done
 
 # Creating Grafana instance and dashboards
 for context in kind-k8s-eu kind-k8s-us; do
@@ -55,5 +54,8 @@ for context in kind-k8s-eu kind-k8s-us; do
 done
 
 # Restart the operator
-kubectl rollout restart deployment -n cnpg-system cnpg-controller-manager
-kubectl rollout status deployment -n cnpg-system cnpg-controller-manager
+if kubectl get ns cnpg-system &> /dev/null
+then
+  kubectl rollout restart deployment -n cnpg-system cnpg-controller-manager
+  kubectl rollout status deployment -n cnpg-system cnpg-controller-manager
+fi

--- a/scripts/monitoring-setup.sh
+++ b/scripts/monitoring-setup.sh
@@ -42,6 +42,10 @@ done
 # Deploying Grafana operator
 for context in kind-k8s-eu kind-k8s-us; do
     kubectl --context $context apply --force-conflicts --server-side=true -f https://github.com/grafana/grafana-operator/releases/latest/download/kustomize-cluster_scoped.yaml
+    kubectl --context=$context -n grafana \
+            patch deployment grafana-operator-controller-manager \
+            --type='merge' --patch='{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/infra","operator":"Exists","effect":"NoSchedule"}],"nodeSelector":{"node-role.kubernetes.io/infra":""}}}}}'
+done
 done
 
 # Creating Grafana instance and dashboards

--- a/scripts/monitoring-setup.sh
+++ b/scripts/monitoring-setup.sh
@@ -1,5 +1,7 @@
 # Copyright The CloudNativePG Contributors
 #
+# Setup a Prometheus/Grafana stack on infrastructure nodes
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -19,7 +21,7 @@ git_repo_root=$(git rev-parse --show-toplevel)
 kube_config_path=${git_repo_root}/k8s/kube-config.yaml
 export KUBECONFIG=${kube_config_path}
 
-# We need to deploy the Prometheus operator in both regions
+# Deploy the Prometheus operator in both Kubernetes clusters
 for context in kind-k8s-eu kind-k8s-us; do
     kubectl --context $context create ns prometheus-operator | true
     kubectl kustomize ${git_repo_root}/k8s/monitoring/prometheus-operator | \
@@ -27,8 +29,7 @@ for context in kind-k8s-eu kind-k8s-us; do
 done
 
 
-# There's dedicated nodes for infrastructure, we make sure that every reosurce
-# is attached to those nodes
+# We make sure that monitoring workloads are deployed in the infrastructure node.
 for context in kind-k8s-eu kind-k8s-us; do
     kubectl kustomize ${git_repo_root}/k8s/monitoring/prometheus-instance | \
         kubectl --context=$context apply --force-conflicts --server-side=true -f - 
@@ -43,7 +44,7 @@ for context in kind-k8s-eu kind-k8s-us; do
     kubectl --context $context apply --force-conflicts --server-side=true -f https://github.com/grafana/grafana-operator/releases/latest/download/kustomize-cluster_scoped.yaml
 done
 
-# Creating Granfa instance and dashboards
+# Creating Grafana instance and dashboards
 for context in kind-k8s-eu kind-k8s-us; do
     kubectl kustomize ${git_repo_root}/k8s/monitoring/grafana/ | \
     kubectl --context $context apply -f -

--- a/scripts/monitoring-setup.sh
+++ b/scripts/monitoring-setup.sh
@@ -32,7 +32,7 @@ done
 # We make sure that monitoring workloads are deployed in the infrastructure node.
 for context in kind-k8s-eu kind-k8s-us; do
     kubectl kustomize ${git_repo_root}/k8s/monitoring/prometheus-instance | \
-        kubectl --context=$context apply --force-conflicts --server-side=true -f - 
+        kubectl --context=$context apply --force-conflicts --server-side=true -f -
     kubectl --context=$context -n prometheus-operator \
             patch deployment prometheus-operator \
             --type='merge' --patch='{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/infra","operator":"Exists","effect":"NoSchedule"}],"nodeSelector":{"node-role.kubernetes.io/infra":""}}}}}'

--- a/scripts/setup_monitoring.sh
+++ b/scripts/setup_monitoring.sh
@@ -1,0 +1,50 @@
+# Copyright The CloudNativePG Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eu
+
+git_repo_root=$(git rev-parse --show-toplevel)
+kube_config_path=${git_repo_root}/k8s/kube-config.yaml
+export KUBECONFIG=${kube_config_path}
+
+# We need to deploy the Prometheus operator in both regions
+for context in kind-k8s-eu kind-k8s-us; do
+    kubectl --context $context create ns prometheus-operator | true
+    kustomize build ${git_repo_root}/k8s/monitoring/prometheus-operator | \
+    kubectl --context $context apply --force-conflicts --server-side=true -f -
+done
+
+
+# There's dedicated nodes for infrastructure, we make sure that every reosurce
+# is attached to those nodes
+for context in kind-k8s-eu kind-k8s-us; do
+    kustomize build ${git_repo_root}/k8s/monitoring/prometheus-instance | \
+        kubectl --context=$context apply --force-conflicts --server-side=true -f - 
+    kubectl --context=$context -n prometheus-operator \
+            patch deployment prometheus-operator \
+            --type='merge' --patch='{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/infra","operator":"Exists","effect":"NoSchedule"}],"nodeSelector":{"node-role.kubernetes.io/infra":""}}}}}'
+done
+
+
+# Deploying Grafana operator
+for context in kind-k8s-eu kind-k8s-us; do
+    kubectl --context $context apply --force-conflicts --server-side=true -f https://github.com/grafana/grafana-operator/releases/latest/download/kustomize-cluster_scoped.yaml
+done
+
+# Creating Granfa instance and dashboards
+for context in kind-k8s-eu kind-k8s-us; do
+    kustomize build ${git_repo_root}/k8s/monitoring/grafana/ | \
+    kubectl --context $context apply -f -
+done

--- a/scripts/setup_monitoring.sh
+++ b/scripts/setup_monitoring.sh
@@ -22,7 +22,7 @@ export KUBECONFIG=${kube_config_path}
 # We need to deploy the Prometheus operator in both regions
 for context in kind-k8s-eu kind-k8s-us; do
     kubectl --context $context create ns prometheus-operator | true
-    kustomize build ${git_repo_root}/k8s/monitoring/prometheus-operator | \
+    kubectl kustomize ${git_repo_root}/k8s/monitoring/prometheus-operator | \
     kubectl --context $context apply --force-conflicts --server-side=true -f -
 done
 
@@ -30,7 +30,7 @@ done
 # There's dedicated nodes for infrastructure, we make sure that every reosurce
 # is attached to those nodes
 for context in kind-k8s-eu kind-k8s-us; do
-    kustomize build ${git_repo_root}/k8s/monitoring/prometheus-instance | \
+    kubectl kustomize ${git_repo_root}/k8s/monitoring/prometheus-instance | \
         kubectl --context=$context apply --force-conflicts --server-side=true -f - 
     kubectl --context=$context -n prometheus-operator \
             patch deployment prometheus-operator \
@@ -45,6 +45,6 @@ done
 
 # Creating Granfa instance and dashboards
 for context in kind-k8s-eu kind-k8s-us; do
-    kustomize build ${git_repo_root}/k8s/monitoring/grafana/ | \
+    kubectl kustomize ${git_repo_root}/k8s/monitoring/grafana/ | \
     kubectl --context $context apply -f -
 done


### PR DESCRIPTION
Every cluster now has the podMonitor enabled and the script scripts/setup_monitoring.sh was created to deploy Prometheus Operator and Grafana Operator, using these operators we create:

* Prometheus instance
* Grafana Deployment
* Grafana Datasource (connecting to Prometheus instance)
* Grafana Dashboard (from the project cloudnative-pg/grafana-dashboard)

After the cluster are updated the Grafana dashboard can be accessed redirecting the 3000 port of the Grafana deployment (namespace grafana) on any of the two kind clusters.

The dashboard is loaded from the URL of the json file in the repository, this means that if the content is changed also the dashboard will be updated.