### PR TITLE
add "backups" directoy to minio to make barman backups work out of the box

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,7 +69,7 @@ cd "${git_repo_root}"
 export KUBECONFIG=${kube_config_path}
 
 # Setup the object stores
-mkdir -p minio-eu
+mkdir -p minio-eu/backups
 $CONTAINER_PROVIDER run \
    --name minio-eu \
 	 -d \
@@ -79,7 +79,7 @@ $CONTAINER_PROVIDER run \
    -u $(id -u):$(id -g) \
    ${MINIO_IMAGE} server /data --console-address ":9001"
 
-mkdir -p minio-us
+mkdir -p minio-us/backups
 $CONTAINER_PROVIDER run \
    --name minio-us \
 	 -d \


### PR DESCRIPTION
Without the backup subdirectorys, no buckets exeist after running ./setup.sh.
Since they are used in .spec.backup.barmanObjectStore.destinationPath of the example files, it maks sence to create them.

Signed-off-by: Daniel Chambre <smiyc@pm.me>