### PR TITLE
feat: add legacy mode to demo script

### DIFF
--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -29,6 +29,11 @@ git_repo_root=$(git rev-parse --show-toplevel)
 kube_config_path=${git_repo_root}/k8s/kube-config.yaml
 demo_yaml_path=${git_repo_root}/demo/yaml
 
+legacy=
+if [ "${LEGACY:-}" = "true" ]; then
+   legacy="-legacy"
+fi
+
 # Ensure prerequisites are met
 prereqs="kubectl kubectl-cnpg cmctl"
 for cmd in $prereqs; do
@@ -80,7 +85,7 @@ for region in eu us; do
 
    # Create the Postgres cluster
    kubectl apply --context kind-k8s-${region} -f \
-     ${demo_yaml_path}/${region}
+     ${demo_yaml_path}/${region}/pg-${region}${legacy}.yaml
 
    # Wait for the cluster to be ready
    kubectl wait --context kind-k8s-${region} \

--- a/demo/yaml/eu/pg-eu-legacy.yaml
+++ b/demo/yaml/eu/pg-eu-legacy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: pg-eu
 spec:
   instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:17-bookworm
 
   storage:
     size: 1Gi

--- a/demo/yaml/eu/pg-eu-legacy.yaml
+++ b/demo/yaml/eu/pg-eu-legacy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: pg-eu
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17-standard-bookworm
 
   storage:
     size: 1Gi
@@ -44,12 +43,19 @@ spec:
       shared_memory_type: 'sysv'
       dynamic_shared_memory_type: 'sysv'
 
-  plugins:
-  - name: barman-cloud.cloudnative-pg.io
-    isWALArchiver: true
-    parameters:
-      barmanObjectName: minio-eu
-      serverName: pg-eu
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://backups/
+      endpointURL: http://minio-eu:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-eu
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-eu
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
 
   # See https://cloudnative-pg.io/documentation/current/replica_cluster/#distributed-topology
   replica:
@@ -59,17 +65,33 @@ spec:
 
   externalClusters:
   - name: pg-eu
-    plugin:
-      name: barman-cloud.cloudnative-pg.io
-      parameters:
-        barmanObjectName: minio-eu
-        serverName: pg-eu
+    barmanObjectStore:
+      serverName: pg-eu
+      destinationPath: s3://backups/
+      endpointURL: http://minio-eu:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-eu
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-eu
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
   - name: pg-us
-    plugin:
-      name: barman-cloud.cloudnative-pg.io
-      parameters:
-        barmanObjectName: minio-us
-        serverName: pg-us
+    barmanObjectStore:
+      serverName: pg-us
+      destinationPath: s3://backups/
+      endpointURL: http://minio-us:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-us
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-us
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
 ---
 # See https://cloudnative-pg.io/documentation/current/backup/#scheduled-backups
 apiVersion: postgresql.cnpg.io/v1
@@ -77,11 +99,8 @@ kind: ScheduledBackup
 metadata:
   name: pg-eu-backup
 spec:
-  method: plugin
   schedule: '0 0 0 * * *'
   backupOwnerReference: self
   cluster:
     name: pg-eu
-  pluginConfiguration:
-    name: barman-cloud.cloudnative-pg.io
   immediate: true

--- a/demo/yaml/us/pg-us-legacy.yaml
+++ b/demo/yaml/us/pg-us-legacy.yaml
@@ -1,10 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: pg-eu
+  name: pg-us
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17-standard-bookworm
 
   storage:
     size: 1Gi
@@ -25,10 +24,10 @@ spec:
     topologyKey: kubernetes.io/hostname
     podAntiAffinityType: required
 
-  # See https://cloudnative-pg.io/documentation/current/bootstrap/#bootstrap-an-empty-cluster-initdb
+  # See https://cloudnative-pg.io/documentation/current/recovery/
   bootstrap:
-    initdb:
-      dataChecksums: true
+    recovery:
+      source: pg-eu
 
   postgresql:
     # See https://cloudnative-pg.io/documentation/current/postgresql_conf/#the-postgresql-section
@@ -44,44 +43,64 @@ spec:
       shared_memory_type: 'sysv'
       dynamic_shared_memory_type: 'sysv'
 
-  plugins:
-  - name: barman-cloud.cloudnative-pg.io
-    isWALArchiver: true
-    parameters:
-      barmanObjectName: minio-eu
-      serverName: pg-eu
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://backups/
+      endpointURL: http://minio-us:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-us
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-us
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
 
   # See https://cloudnative-pg.io/documentation/current/replica_cluster/#distributed-topology
   replica:
-    self: pg-eu
+    self: pg-us
     primary: pg-eu
-    source: pg-us
+    source: pg-eu
 
   externalClusters:
   - name: pg-eu
-    plugin:
-      name: barman-cloud.cloudnative-pg.io
-      parameters:
-        barmanObjectName: minio-eu
-        serverName: pg-eu
+    barmanObjectStore:
+      serverName: pg-eu
+      destinationPath: s3://backups/
+      endpointURL: http://minio-eu:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-eu
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-eu
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
   - name: pg-us
-    plugin:
-      name: barman-cloud.cloudnative-pg.io
-      parameters:
-        barmanObjectName: minio-us
-        serverName: pg-us
+    barmanObjectStore:
+      serverName: pg-us
+      destinationPath: s3://backups/
+      endpointURL: http://minio-us:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-us
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-us
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
 ---
 # See https://cloudnative-pg.io/documentation/current/backup/#scheduled-backups
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: pg-eu-backup
+  name: pg-us-backup
 spec:
-  method: plugin
   schedule: '0 0 0 * * *'
   backupOwnerReference: self
   cluster:
-    name: pg-eu
-  pluginConfiguration:
-    name: barman-cloud.cloudnative-pg.io
+    name: pg-us
   immediate: true

--- a/demo/yaml/us/pg-us-legacy.yaml
+++ b/demo/yaml/us/pg-us-legacy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: pg-us
 spec:
   instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:17-bookworm
 
   storage:
     size: 1Gi

--- a/demo/yaml/us/pg-us.yaml
+++ b/demo/yaml/us/pg-us.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-us
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17-minimal-bookworm
+  imageName: ghcr.io/cloudnative-pg/postgresql:17-standard-bookworm
 
   storage:
     size: 1Gi


### PR DESCRIPTION
Add the legacy mode using the in-tree backup configuration.

To create a legacy demo environment, use

```
LEGACY=true demo/setup.sh
```

Closes #22 