### PR TITLE
feat: additional utilities for flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,13 @@
       shellHook = ''
         # Setup 'k' as a 'kubectl' alias
         source <(kubectl completion bash)
-
         alias k=kubectl
         complete -o default -F __start_kubectl k
+
+        # Setup 'kc' as a 'kubectl cnpg' alias
+        source <(kubectl cnpg completion bash)
+        alias kc="kubectl cnpg"
+        complete -o default -F __start_kubectl-cnpg kc
       '';
 
       packages = [
@@ -28,6 +32,10 @@
         pkgs.curl
         pkgs.kubectl-cnpg
         pkgs.kubectl-view-secret
+        pkgs.cmctl
+        pkgs.k9s
+        pkgs.lazydocker
+        pkgs.btop
      ];
     };
   });


### PR DESCRIPTION
add cmctl, k9s, lazydocker and btop. also configure command completion for cnpg plugin since its already done for kubectl.