### PR TITLE
feat: MinIO persistence across reboots

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,6 +77,8 @@ $CONTAINER_PROVIDER run \
    -e "MINIO_ROOT_USER=$MINIO_EU_ROOT_USER" \
    -e "MINIO_ROOT_PASSWORD=$MINIO_EU_ROOT_PASSWORD" \
    -u $(id -u):$(id -g) \
+   -p 19001:9001 \
+   --restart always \
    ${MINIO_IMAGE} server /data --console-address ":9001"
 
 mkdir -p minio-us
@@ -87,6 +89,8 @@ $CONTAINER_PROVIDER run \
    -e "MINIO_ROOT_USER=$MINIO_US_ROOT_USER" \
    -e "MINIO_ROOT_PASSWORD=$MINIO_US_ROOT_PASSWORD" \
    -u $(id -u):$(id -g) \
+   -p 29001:9001 \
+   --restart always \
    ${MINIO_IMAGE} server /data --console-address ":9001"
 
 # Setup the EU Kind Cluster


### PR DESCRIPTION
When using the CNPG Playground, if the host is rebooted then the docker containers that belong to kind clusters will all restart automatically however the MinIO docker containers do not start up. This isn't always obvious to users, who might then need to spend time trying to figure out why their CNPG clusters run but backups are failing.

This PR sets a restart policy on the MinIO containers so that they will come back online automatically after host reboots.

I had also bookmarked the MinIO console in my browser, but the MinIO containers sometimes restart in a different order, resulting in unpredictable IP address which breaks the bookmarks. To address this, I've also added an option to publish the MinIO console ports on localhost. I prefixed EU cluster ports with "1" and US cluster ports with "2" so the MinIO ports are 19001 and 29001. The same pattern could also be considered for grafana ports in the future (ie 13000 and 23000).