### PR TITLE
chore(demo): add `TRUNK` option for deploying snapshot builds

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -38,7 +38,7 @@ the two regions using:
 ```
 
 This process takes a few minutes to complete.
-It installs the latest snapshot version of CloudNativePG, cert-manager, and the
+It installs the latest version of CloudNativePG, cert-manager, and the
 [Barman Cloud plugin](https://cloudnative-pg.io/plugin-barman-cloud/),
 followed by the deployment of the two PostgreSQL clusters.
 
@@ -47,6 +47,13 @@ Barman Cloud code instead of the Barman Cloud Plugin, simply run:
 
 ```sh
 LEGACY=true ./demo/setup.sh
+```
+
+To deploy from the latest `main` branch of both CloudNativePG and the Barman
+Cloud plugin, use:
+
+```bash
+TRUNK=true ./demo/setup.sh
 ```
 
 For a detailed understanding of the deployment process, refer to the

--- a/demo/yaml/eu/pg-eu-legacy.yaml
+++ b/demo/yaml/eu/pg-eu-legacy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-eu
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17-bookworm
+  imageName: ghcr.io/cloudnative-pg/postgresql:17-system-trixie
 
   storage:
     size: 1Gi

--- a/demo/yaml/eu/pg-eu.yaml
+++ b/demo/yaml/eu/pg-eu.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-eu
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17-standard-bookworm
+  imageName: ghcr.io/cloudnative-pg/postgresql:17-standard-trixie
 
   storage:
     size: 1Gi


### PR DESCRIPTION
Enable deployment of snapshot builds by running the script with `TRUNK=true`. In this mode, the latest snapshots of both CloudNativePG and the Barman Cloud plugin are used; otherwise, the latest stable releases are applied.

Closes #34