### PR TITLE
introduce funcs_regions.sh

### DIFF
--- a/monitoring/setup.sh
+++ b/monitoring/setup.sh
@@ -28,15 +28,7 @@ source $(git rev-parse --show-toplevel)/scripts/common.sh
 
 # --- Main Logic ---
 # Determine regions from arguments, or auto-detect if none are provided
-REGIONS=()
-if [ $# -gt 0 ]; then
-    REGIONS=("$@")
-    echo "🎯 Targeting specified regions for monitoring setup: ${REGIONS[*]}"
-else
-    echo "🔎 Auto-detecting all active playground regions for monitoring setup..."
-    # The '|| true' prevents the script from exiting if grep finds no matches.
-    REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}-" | sed "s/^${K8S_BASE_NAME}-//" || true))
-fi
+detect_running_regions "$@"
 
 # Add a target port for the port-forward, the port will be incremeted by 1 for each region
 port=3000

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,6 +21,10 @@
 
 set -euo pipefail
 
+# --- Common Configuration ---
+# Kind base name for clusters
+K8S_BASE_NAME=${K8S_NAME:-k8s}
+
 # MinIO Configuration
 MINIO_IMAGE="${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z}"
 MINIO_BASE_NAME="${MINIO_BASE_NAME:-minio}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,10 +21,6 @@
 
 set -euo pipefail
 
-# --- Common Configuration ---
-# Kind base name for clusters
-# K8S_BASE_NAME=${K8S_NAME:-k8s}
-
 # MinIO Configuration
 MINIO_IMAGE="${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z}"
 MINIO_BASE_NAME="${MINIO_BASE_NAME:-minio}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 # --- Common Configuration ---
 # Kind base name for clusters
-K8S_BASE_NAME=${K8S_NAME:-k8s}
+# K8S_BASE_NAME=${K8S_NAME:-k8s}
 
 # MinIO Configuration
 MINIO_IMAGE="${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z}"
@@ -59,3 +59,6 @@ fi
 # Determine project root and kubeconfig path
 GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
 KUBE_CONFIG_PATH="${GIT_REPO_ROOT}/k8s/kube-config.yaml"
+
+# source funcs_regions.sh
+source $(git rev-parse --show-toplevel)/scripts/funcs_regions.sh

--- a/scripts/funcs_regions.sh
+++ b/scripts/funcs_regions.sh
@@ -23,10 +23,6 @@
 
 set -euo pipefail
 
-# --- Common Configuration ---
-# Kind base name for clusters
-K8S_BASE_NAME=${K8S_NAME:-k8s}
-
 # --- Set regions ---
 # if called with an argument, $REGIONS is set to it's value
 # if no argument is provided, $REGIONS is set to the defualt regions "eu" and "us"

--- a/scripts/funcs_regions.sh
+++ b/scripts/funcs_regions.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# This script installs and configures the Prometheus and Grafana operators.
+# When run without arguments, it automatically detects all cnpg-playground
+# Kind clusters in your environment and deploys the monitoring stack for each.
+# To install monitoring for specific regions only, pass the region names as arguments.
+#
+#
+# Copyright The CloudNativePG Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+# --- Common Configuration ---
+# Kind base name for clusters
+K8S_BASE_NAME=${K8S_NAME:-k8s}
+
+# --- Set regions ---
+# if called with an argument, $REGIONS is set to it's value
+# if no argument is provided, $REGIONS is set to the defualt regions "eu" and "us"
+set_regions() {
+    if [ $# -eq 0 ]; then
+        REGIONS=("eu" "us")
+        echo "❌ No region provided, using the default regions "eu" "us"..."
+    else
+        REGIONS=("$@")
+        echo "🔎 Using the provided regions: ${REGIONS[*]}"
+    fi
+}
+
+# --- detect regions ---
+# if called with an argument, $REGIONS is set to it's value
+# if no argument is provided, $REGIONS is set to the running kind clusters
+detect_running_regions() {
+    if [ $# -gt 0 ]; then
+        REGIONS=("$@")
+        echo "🎯 Targeting specified regions: ${REGIONS[*]}"
+    else
+        echo "🔎 Auto-detecting all active playground regions..."
+        # The '|| true' prevents the script from exiting if grep finds no matches.
+        REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}-" | sed "s/^${K8S_BASE_NAME}-//" || true))
+        echo "✅ Found regions: ${REGIONS[*]}"
+    fi
+}

--- a/scripts/funcs_regions.sh
+++ b/scripts/funcs_regions.sh
@@ -3,7 +3,7 @@
 # This script contains the functions used to set the ${REGIONS} variable.
 # set_regions() --> if called without an argument, EU and US are set
 #                   otherwise the arguments.
-#                   
+#
 # detect_running_regions() -->  if called without an argument, the running
 #                               CNPG-Playground Kind clusters regions are set
 #                               otherwise the arguments.
@@ -46,6 +46,10 @@ detect_running_regions() {
         echo "🔎 Auto-detecting all active playground regions..."
         # The '|| true' prevents the script from exiting if grep finds no matches.
         REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}-" | sed "s/^${K8S_BASE_NAME}-//" || true))
-        echo "✅ Found regions: ${REGIONS[*]}"
+        if [ ${#REGIONS[@]} -gt 0 ]; then
+            echo "✅ Found regions: ${REGIONS[*]}"
+	else
+            echo "✅ No region detected"
+	fi
     fi
 }

--- a/scripts/funcs_regions.sh
+++ b/scripts/funcs_regions.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 #
-# This script installs and configures the Prometheus and Grafana operators.
-# When run without arguments, it automatically detects all cnpg-playground
-# Kind clusters in your environment and deploys the monitoring stack for each.
-# To install monitoring for specific regions only, pass the region names as arguments.
+# This script contains the functions used to set the ${REGIONS} variable.
+# set_regions() --> if called without an argument, EU and US are set
+#                   otherwise the arguments.
+#                   
+# detect_running_regions() -->  if called without an argument, the running
+#                               CNPG-Playground Kind clusters regions are set
+#                               otherwise the arguments.
 #
 #
 # Copyright The CloudNativePG Contributors
@@ -24,8 +27,6 @@
 set -euo pipefail
 
 # --- Set regions ---
-# if called with an argument, $REGIONS is set to it's value
-# if no argument is provided, $REGIONS is set to the defualt regions "eu" and "us"
 set_regions() {
     if [ $# -eq 0 ]; then
         REGIONS=("eu" "us")
@@ -37,8 +38,6 @@ set_regions() {
 }
 
 # --- detect regions ---
-# if called with an argument, $REGIONS is set to it's value
-# if no argument is provided, $REGIONS is set to the running kind clusters
 detect_running_regions() {
     if [ $# -gt 0 ]; then
         REGIONS=("$@")

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -30,14 +30,7 @@ fi
 export KUBECONFIG="${KUBE_CONFIG_PATH}"
 
 # --- Auto-detect Regions ---
-echo "🔎 Detecting active playground clusters..."
-REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}-" | sed "s/^${K8S_BASE_NAME}-//" || true))
-
-if [ ${#REGIONS[@]} -eq 0 ]; then
-    echo "🤷 No active playground clusters found with the prefix '${K8S_BASE_NAME}-'."
-    exit 0
-fi
-echo "✅ Found regions: ${REGIONS[*]}"
+detect_running_regions
 
 # --- Access Instructions ---
 echo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -53,10 +53,7 @@ echo
 
 # --- Script Setup ---
 # Determine regions from arguments, or use defaults
-REGIONS=("$@")
-if [ ${#REGIONS[@]} -eq 0 ]; then
-    REGIONS=("eu" "us")
-fi
+set_regions "$@"
 
 # Setup a single, shared Kubeconfig for all clusters
 export KUBECONFIG="${KUBE_CONFIG_PATH}"

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -23,22 +23,7 @@ source "$(dirname "$0")/common.sh"
 
 # --- Main Logic ---
 # Determine regions from arguments, or auto-detect if none are provided
-REGIONS=()
-if [ $# -gt 0 ]; then
-    REGIONS=("$@")
-    echo "🎯 Targeting specified regions for teardown: ${REGIONS[*]}"
-else
-    echo "🔎 Auto-detecting all active playground regions for teardown..."
-    # The '|| true' prevents the script from exiting if grep finds no matches.
-    REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}-" | sed "s/^${K8S_BASE_NAME}-//" || true))
-fi
-
-if [ ${#REGIONS[@]} -eq 0 ]; then
-    echo "🤷 No regions found to tear down. Exiting."
-    exit 0
-fi
-
-echo "🔥 Tearing down regions: ${REGIONS[*]}"
+detect_running_regions "$@"
 
 for region in "${REGIONS[@]}"; do
     K8S_CLUSTER_NAME="${K8S_BASE_NAME}-${region}"


### PR DESCRIPTION
This PR introduces a new script: func_regions.sh which is sourced by common.sh

Included functions are:

set_regions() --> set $REGIONS to the provided arguments, if no arguments are provided the default regions "eu" and "us" are used

detect_running_regions() --> set $REGIONS to the provided arguments, if no arguments are provided the running regions are extraced from ´kind get clusters´

closes #39

Signed-off-by: Daniel Chambre <smiyc@pm.me>