### PR TITLE
fix: add missing podmonitor files

### DIFF
--- a/demo/yaml/eu/pg-eu-podmonitor.yaml
+++ b/demo/yaml/eu/pg-eu-podmonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: pg-eu
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: pg-eu
+  podMetricsEndpoints:
+  - port: metrics

--- a/demo/yaml/us/pg-us-podmonitor.yaml
+++ b/demo/yaml/us/pg-us-podmonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: pg-us
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: pg-us
+  podMetricsEndpoints:
+  - port: metrics


### PR DESCRIPTION
feat #38 updated demo/setup.sh with a dependency on podmonitor files in demo/yaml but forgot to add the files themselves. this fix adds the missing files.

Closes #42