### PR TITLE
fix: add missing grafana rbac

### DIFF
--- a/monitoring/grafana/grafana_instance.yaml
+++ b/monitoring/grafana/grafana_instance.yaml
@@ -1,3 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana
+  namespace: grafana
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: grafana-operator-update
+  namespace: grafana
+rules:
+  - apiGroups: ["grafana.integreatly.org"]
+    resources: ["grafanas"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grafana-operator-update
+  namespace: grafana
+subjects:
+  - kind: ServiceAccount
+    name: grafana-operator-controller-manager
+    namespace: grafana
+roleRef:
+  kind: Role
+  name: grafana-operator-update
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
@@ -15,5 +45,6 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: grafana
           nodeSelector:
             node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
feat #38 installs grafana official operator with kustomize however grafana fails to start due to missing `update` rbac privs. this fix adds the missing privs, following the same pattern as `monitoring/prometheus-instance/deploy_prometheus.yaml`.

Closes #44