### PR TITLE
fix: disable Grafana Live to prevent port-forward timeouts

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,6 +60,12 @@ You can find the dashboard under `Home > Dashboards > grafana > CloudNativePG`.
 
 ![dashboard](image.png)
 
+> **Note:** Grafana Live is disabled (`max_connections: 0`) to prevent
+> WebSocket connection buildup that can exhaust kubectl port-forward
+> streams and cause timeout errors. This means real-time dashboard
+> streaming is unavailable, but all other Grafana features work normally
+> when accessed via port-forward.
+
 ## PodMonitor
 
 To enable Prometheus to scrape metrics from your PostgreSQL pods, you must

--- a/monitoring/grafana/grafana_instance.yaml
+++ b/monitoring/grafana/grafana_instance.yaml
@@ -11,6 +11,8 @@ spec:
     security:
       admin_user: admin
       admin_password: admin
+    live:
+      max_connections: "0"
   deployment:
     spec:
       template:


### PR DESCRIPTION
Disable Grafana Live feature (max_connections=0) to prevent WebSocket connection buildup that causes kubectl port-forward timeout errors. Firefox creates multiple persistent connections that exhausts the port-forward stream multiplexer. This causes grafana to quickly become unresponsive in the browser and the following errors to be thrown:

```
kubectl port-forward service/grafana-service 3000:3000 -n grafana --context kind-k8s-eu
...
Handling connection for 3000
E0108 03:26:47.977808  812338 portforward.go:351] "Unhandled Error" err="error creating error stream for port 3000 -> 3000: Timeout occurred"
E0108 03:26:47.979969  812338 portforward.go:374] "Unhandled Error" err="error creating forwarding stream for port 3000 -> 3000: Timeout occurred"
E0108 03:26:56.184349  812338 portforward.go:374] "Unhandled Error" err="error creating forwarding stream for port 3000 -> 3000: Timeout occurred"
E0108 03:27:08.983705  812338 portforward.go:374] "Unhandled Error" err="error creating forwarding stream for port 3000 -> 3000: Timeout occurred"
E0108 03:27:09.537632  812338 portforward.go:351] "Unhandled Error" err="error creating error stream for port 3000 -> 3000: Timeout occurred"
Handling connection for 3000
Handling connection for 3000
E0108 03:27:09.556133  812338 portforward.go:374] "Unhandled Error" err="error creating forwarding stream for port 3000 -> 3000: Timeout occurred"
E0108 03:27:10.928121  812338 portforward.go:351] "Unhandled Error" err="error creating error stream for port 3000 -> 3000: Timeout occurred"
E0108 03:27:10.930587  812338 portforward.go:374] "Unhandled Error" err="error creating forwarding stream for port 3000 -> 3000: Timeout occurred"
Handling connection for 3000
E0108 03:27:12.022278  812338 portforward.go:374] "Unhandled Error" err="error creating forwarding stream for port 3000 -> 3000: Timeout occurred"
Handling connection for 3000
Handling connection for 3000
```

Docs:
https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#live