### PR TITLE
update grafana port-forward to be 1-based

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -38,14 +38,14 @@ The `setup.sh` script prints the exact commands needed.
 For the default two-region environment, they look similar to:
 
 ```bash
-kubectl port-forward service/grafana-service 3000:3000 -n grafana --context kind-k8s-eu
-kubectl port-forward service/grafana-service 3001:3000 -n grafana --context kind-k8s-us
+kubectl port-forward service/grafana-service 3001:3000 -n grafana --context kind-k8s-eu
+kubectl port-forward service/grafana-service 3002:3000 -n grafana --context kind-k8s-us
 ```
 
 After forwarding the port, open your browser at:
 
 ```
-http://localhost:3000
+http://localhost:3001
 ```
 
 Log in using:

--- a/monitoring/setup.sh
+++ b/monitoring/setup.sh
@@ -39,7 +39,7 @@ else
 fi
 
 # Add a target port for the port-forward, the port will be incremeted by 1 for each region
-port=3000
+port=3001
 
 for region in "${REGIONS[@]}"; do
     echo "-------------------------------------------------------------"


### PR DESCRIPTION
update grafana port-forward to start at 3001 to be consistent with minio
port forwarding and to be a little easier for users to keep track of
ports for multiple regions

Closes #50

Signed-off-by: Jeremy Schneider <schneider@ardentperf.com>
