### PR TITLE
fix(script): setup playground with rootless podman

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -86,6 +86,9 @@ for region in "${REGIONS[@]}"; do
         "${MINIO_IMAGE}" server /data --console-address ":9001" > /dev/null
 
     echo "🏗️  Creating Kind cluster '${K8S_CLUSTER_NAME}'..."
+    if [ "$CONTAINER_PROVIDER" == "podman" ]; then
+        export KIND_EXPERIMENTAL_PROVIDER=podman
+    fi
     kind create cluster --config "${kind_config_path}" --name "${K8S_CLUSTER_NAME}"
 
     echo "🏷️  Labeling nodes in '${K8S_CLUSTER_NAME}'..."


### PR DESCRIPTION
This PR fix the setup  `script/setup.sh` to be usable on [rootless podman](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) as
described in [kind docs](https://kind.sigs.k8s.io/docs/user/rootless/#creating-a-kind-cluster-with-rootless-podman)

The issue when running the script without the PR:
```bash
Command Output: time="xxxxx" level=fatal msg="rootless containerd not running? (hint: use `containerd-rootless-setuptool.sh install` to start rootless containerd): stat /run/user/1000/containerd-rootless: no such file or directory"
```

Output after PR:

```bash

--------------------------------------------------
🚀 Provisioning resources for region: eu
--------------------------------------------------
📦 Creating MinIO container 'minio-eu' on host port 9001...
🏗️  Creating Kind cluster 'k8s-eu'...
using podman due to KIND_EXPERIMENTAL_PROVIDER   ####  <------
enabling experimental podman provider
Creating cluster "k8s-eu" ...
 ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
 
...
```
