### PR TITLE
refactor: centralise k8s context and cluster naming logic

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -23,7 +23,8 @@ set -euo pipefail
 
 # --- Common Configuration ---
 # Kind base name for clusters
-K8S_BASE_NAME=${K8S_NAME:-k8s}
+K8S_CONTEXT_PREFIX=${K8S_CONTEXT_PREFIX-kind-}
+K8S_BASE_NAME=${K8S_NAME-k8s-}
 
 # MinIO Configuration
 MINIO_IMAGE="${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z}"

--- a/scripts/funcs_regions.sh
+++ b/scripts/funcs_regions.sh
@@ -45,11 +45,23 @@ detect_running_regions() {
     else
         echo "🔎 Auto-detecting all active playground regions..."
         # The '|| true' prevents the script from exiting if grep finds no matches.
-        REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}-" | sed "s/^${K8S_BASE_NAME}-//" || true))
+        REGIONS=($(kind get clusters | grep "^${K8S_BASE_NAME}" | sed "s/^${K8S_BASE_NAME}//" || true))
         if [ ${#REGIONS[@]} -gt 0 ]; then
             echo "✅ Found regions: ${REGIONS[*]}"
 	else
             echo "✅ No region detected"
 	fi
     fi
+}
+
+# Helper function that builds the name of the cluster in a standard way given the region
+get_cluster_name() {
+    local region="$1"
+    echo "${K8S_BASE_NAME}${region}"
+}
+
+# Helper function that builds the name of the context in a standard way given the region
+get_cluster_context() {
+    local region="$1"
+    echo "${K8S_CONTEXT_PREFIX}${K8S_BASE_NAME}${region}"
 }

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -43,11 +43,12 @@ echo "export KUBECONFIG=${KUBE_CONFIG_PATH}"
 echo
 echo "Available cluster contexts:"
 for region in "${REGIONS[@]}"; do
-    echo "  • kind-${K8S_BASE_NAME}-${region}"
+    CONTEXT_NAME=$(get_cluster_context "${region}")
+    echo "  • ${CONTEXT_NAME}"
 done
 echo
 echo "To switch to a specific cluster (e.g., the '${REGIONS[0]}' region), use:"
-echo "kubectl config use-context kind-${K8S_BASE_NAME}-${REGIONS[0]}"
+echo "kubectl config use-context $(get_cluster_context ${REGIONS[0]})"
 echo
 
 # --- Main Info Loop ---
@@ -55,16 +56,17 @@ echo "--------------------------------------------------"
 echo "ℹ️  Cluster Information"
 echo "--------------------------------------------------"
 for region in "${REGIONS[@]}"; do
-    CONTEXT="kind-${K8S_BASE_NAME}-${region}"
+    CLUSTER_NAME=$(get_cluster_name "${region}")
+    CONTEXT_NAME=$(get_cluster_context "${region}")
     echo
-    echo "🔷 Cluster: ${CONTEXT}"
+    echo "🔷 Cluster: ${CLUSTER_NAME}"
     echo "==================================="
     echo "🔹 Version:"
-    kubectl --context "${CONTEXT}" version
+    kubectl --context "${CONTEXT_NAME}" version
     echo
     echo "🔹 Nodes:"
-    kubectl --context "${CONTEXT}" get nodes -o wide
+    kubectl --context "${CONTEXT_NAME}" get nodes -o wide
     echo
     echo "🔹 Secrets:"
-    kubectl --context "${CONTEXT}" get secrets
+    kubectl --context "${CONTEXT_NAME}" get secrets
 done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,14 +37,14 @@ echo "✅ Prerequisites met. Using '$CONTAINER_PROVIDER' as the container provid
 # --- Pre-flight Check ---
 echo "🔎 Verifying that no existing playground clusters are running..."
 # The '|| true' prevents the script from exiting if grep finds no matches.
-existing_count=$(kind get clusters | grep -c "^${K8S_BASE_NAME}-" || true)
+existing_count=$(kind get clusters | grep -c "^${K8S_BASE_NAME}" || true)
 
 if [ "${existing_count}" -gt 0 ]; then
     echo "❌ Error: Found ${existing_count} existing playground cluster(s)."
     echo "Please run './scripts/teardown.sh' to remove the existing environment before running setup."
     echo
     echo "Found clusters:"
-    kind get clusters | grep "^${K8S_BASE_NAME}-"
+    kind get clusters | grep "^${K8S_BASE_NAME}"
     exit 1
 fi
 
@@ -70,7 +70,7 @@ for region in "${REGIONS[@]}"; do
     echo "🚀 Provisioning resources for region: ${region}"
     echo "--------------------------------------------------"
 
-    K8S_CLUSTER_NAME="${K8S_BASE_NAME}-${region}"
+    K8S_CLUSTER_NAME=$(get_cluster_name "${region}")
     MINIO_CONTAINER_NAME="${MINIO_BASE_NAME}-${region}"
 
     echo "📦 Creating MinIO container '${MINIO_CONTAINER_NAME}' on host port ${current_minio_port}..."
@@ -107,7 +107,7 @@ echo "--------------------------------------------------"
 echo "🔑 Distributing MinIO secrets to all clusters"
 echo "--------------------------------------------------"
 for target_region in "${REGIONS[@]}"; do
-    target_cluster_context="kind-${K8S_BASE_NAME}-${target_region}"
+    target_cluster_context=$(get_cluster_context "${target_region}")
     echo "   -> Configuring secrets in cluster: ${target_cluster_context}"
 
     for source_minio_name in "${all_minio_names[@]}"; do

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -25,10 +25,17 @@ source "$(dirname "$0")/common.sh"
 # Determine regions from arguments, or auto-detect if none are provided
 detect_running_regions "$@"
 
+if [ ${#REGIONS[@]} -eq 0 ]; then
+    echo "🤷 No regions found to tear down. Exiting."
+    exit 0
+fi
+
+echo "🔥 Tearing down regions: ${REGIONS[*]}"
+
 for region in "${REGIONS[@]}"; do
-    K8S_CLUSTER_NAME="${K8S_BASE_NAME}-${region}"
+    K8S_CLUSTER_NAME=$(get_cluster_name "${region}")
+    CONTEXT_NAME=$(get_cluster_context "${region}")
     MINIO_CONTAINER_NAME="${MINIO_BASE_NAME}-${region}"
-    CONTEXT_NAME="kind-${K8S_CLUSTER_NAME}"
 
     echo "--------------------------------------------------"
     echo "🔥 Tearing down region: ${region}"


### PR DESCRIPTION
Introduces the `get_cluster_context` and `get_cluster_name` helper functions to standardise how names are derived from environment variables.

- Uses K8S_CONTEXT_PREFIX (default: kind-) and K8S_BASE_NAME (default: k8s-).
- Ensures consistent string concatenation across the scripts.