### PR TITLE
chore: update nix devshell versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729256560,
-        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The nix devshell pins versions for much of the sandbox - not only command line utilities, but even kubernetes and cnpg themselves via kind and the kubectl cnpg plugin. current versions are from october 2024; this brings versions up-to-date as of january 2026.

Will run an E2E test and post results in PR

Summary:

---

## Flake.lock Details

| Aspect | Old Snapshot | New Snapshot |
|--------|--------------|--------------|
| **nixpkgs Date** | October 18, 2024 | January 11, 2026 |
| **nixpkgs Commit** | `4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0` | `ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38` |
| **flake-utils Date** | September 17, 2024 | November 13, 2024 |

## Utility Version Changes

| Utility | Old Version | New Version | Change |
|---------|-------------|-------------|--------|
| **kubectl** | v1.31.0 | **v1.35.0** | ⬆ **+4 minor versions** |
| **kubectx** | 0.9.5 | 0.9.5 | ✅ No change |
| **helm** | v3.16.1 | **v3.19.1** | ⬆ **+3 minor versions** |
| **kind** | v0.24.0 | **v0.31.0** | ⬆ **+7 minor versions** |
| **jq** | 1.7.1 | **1.8.1** | ⬆ **+1 minor version** |
| **curl** | 8.9.1 | **8.17.0** | ⬆ **+8 minor versions** |
| **kubectl-cnpg** | 1.24.0 | **1.28.0** | ⬆ **+4 minor versions** |
| **stern** | 1.30.0 | **1.33.1** | ⬆ **+3 minor versions** |
| **cmctl** | v1.14.7 | **v2.3.0** | ⬆ **+1 major version** |
| **k9s** | 0.32.5 | **0.50.16** | ⬆ **+18 minor versions** |
| **lazydocker** | 0.23.3 | **0.24.3** | ⬆ **+1 minor version** |
| **btop** | 1.4.0 | **1.4.6** | ⬆ **+6 patch versions** |

## Kubernetes & CNPG Versions

| Component | Old Version | New Version | Determined By |
|-----------|---------|--------------|--------|
| **Kustomize** | v5.4.2 | **v5.7.1** | from kubectl |
| **Kubernetes** | v1.31.0 | **v1.35.0** | from kind |
| **CNPG Operator** | 1.24.0 | **1.28.0** | from kubectl-cnpg |
