### PR TITLE
fix: podmonitor name cant match cluster name

### DIFF
--- a/demo/yaml/eu/pg-eu-podmonitor.yaml
+++ b/demo/yaml/eu/pg-eu-podmonitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: pg-eu
+  name: pg-eu-podmonitor
 spec:
   selector:
     matchLabels:

--- a/demo/yaml/us/pg-us-podmonitor.yaml
+++ b/demo/yaml/us/pg-us-podmonitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: pg-us
+  name: pg-us-podmonitor
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
the podmonitor name cant match the cnpg cluster name or the operator will delete the podmonitor (cf. https://github.com/cloudnative-pg/cloudnative-pg/issues/6109 and https://github.com/cloudnative-pg/cloudnative-pg/issues/8075 ). rename the podmonitor as a workaround.

Successful E2E test https://github.com/ardentperf/cnpg-playground/actions/runs/21018873879

Closes #46 
