### PR TITLE
feat(demo): allow template customisation via env vars

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -116,6 +116,46 @@ Kubernetes clusters rather than the Kind clusters created by
 For example, if your contexts are named `eu` and `us`, set both to empty
 strings: `K8S_CONTEXT_PREFIX="" K8S_NAME="" ./demo/setup.sh eu us`.
 
+### Template customisation
+
+`demo/setup.sh` renders YAML from the fragments in `demo/templates/` using
+`envsubst`. You can replace the entire directory or override individual
+fragments without modifying the repository.
+
+| Variable | Description |
+|----------|-------------|
+| `TEMPLATES_DIR=<path>` | Replace the whole templates directory with your own |
+| `CLUSTER_TEMPLATE=<file>` | Override `cluster.yaml` only |
+| `BOOTSTRAP_INITDB_TEMPLATE=<file>` | Override `bootstrap-initdb.yaml` |
+| `BOOTSTRAP_RECOVERY_TEMPLATE=<file>` | Override `bootstrap-recovery.yaml` |
+| `CLUSTER_PLUGIN_PARAMS_TEMPLATE=<file>` | Override `cluster-plugin-params.yaml` |
+| `REPLICA_SECTION_TEMPLATE=<file>` | Override `replica-section.yaml` |
+| `EXTERNAL_CLUSTER_PLUGIN_TEMPLATE=<file>` | Override `external-cluster-plugin.yaml` |
+| `SCHEDULEDBACKUP_PLUGIN_TEMPLATE=<file>` | Override `scheduledbackup-plugin.yaml` |
+| `OBJECTSTORE_TEMPLATE=<file>` | Override `objectstore.yaml` |
+| `PODMONITOR_TEMPLATE=<file>` | Override `podmonitor.yaml` |
+
+Legacy-mode equivalents (used with `LEGACY=true`):
+
+| Variable | Description |
+|----------|-------------|
+| `CLUSTER_LEGACY_PARAMS_TEMPLATE=<file>` | Override `legacy/cluster-legacy-params.yaml` |
+| `EXTERNAL_CLUSTER_LEGACY_TEMPLATE=<file>` | Override `legacy/external-cluster-legacy.yaml` |
+| `SCHEDULEDBACKUP_LEGACY_TEMPLATE=<file>` | Override `legacy/scheduledbackup-legacy.yaml` |
+
+Examples:
+
+```bash
+# Use a completely custom templates directory
+TEMPLATES_DIR=/path/to/my-templates ./demo/setup.sh
+
+# Override only the Cluster fragment, keep everything else
+CLUSTER_TEMPLATE=/path/to/my-cluster.yaml ./demo/setup.sh
+
+# Preview the result of your custom template without applying
+DRY_RUN=true CLUSTER_TEMPLATE=/path/to/my-cluster.yaml ./demo/setup.sh
+```
+
 Examples:
 
 ```bash

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -43,12 +43,26 @@ git_repo_root=$(git rev-parse --show-toplevel)
 source "${git_repo_root}/scripts/common.sh"
 
 kube_config_path="${git_repo_root}/k8s/kube-config.yaml"
-templates_dir="${git_repo_root}/demo/templates"
+templates_dir="${TEMPLATES_DIR:-${git_repo_root}/demo/templates}"
 legacy_templates_dir="${templates_dir}/legacy"
 
 # Default PostgreSQL image (overridable via env var)
 POSTGRESQL_IMAGE="${POSTGRESQL_IMAGE:-ghcr.io/cloudnative-pg/postgresql:18-standard-trixie}"
 POSTGRESQL_LEGACY_IMAGE="${POSTGRESQL_LEGACY_IMAGE:-ghcr.io/cloudnative-pg/postgresql:18-system-trixie}"
+
+# Template file overrides — set any of these to replace the corresponding built-in fragment
+tmpl_cluster="${CLUSTER_TEMPLATE:-${templates_dir}/cluster.yaml}"
+tmpl_bootstrap_initdb="${BOOTSTRAP_INITDB_TEMPLATE:-${templates_dir}/bootstrap-initdb.yaml}"
+tmpl_bootstrap_recovery="${BOOTSTRAP_RECOVERY_TEMPLATE:-${templates_dir}/bootstrap-recovery.yaml}"
+tmpl_cluster_plugin_params="${CLUSTER_PLUGIN_PARAMS_TEMPLATE:-${templates_dir}/cluster-plugin-params.yaml}"
+tmpl_replica_section="${REPLICA_SECTION_TEMPLATE:-${templates_dir}/replica-section.yaml}"
+tmpl_external_cluster_plugin="${EXTERNAL_CLUSTER_PLUGIN_TEMPLATE:-${templates_dir}/external-cluster-plugin.yaml}"
+tmpl_scheduledbackup_plugin="${SCHEDULEDBACKUP_PLUGIN_TEMPLATE:-${templates_dir}/scheduledbackup-plugin.yaml}"
+tmpl_objectstore="${OBJECTSTORE_TEMPLATE:-${templates_dir}/objectstore.yaml}"
+tmpl_podmonitor="${PODMONITOR_TEMPLATE:-${templates_dir}/podmonitor.yaml}"
+tmpl_cluster_legacy_params="${CLUSTER_LEGACY_PARAMS_TEMPLATE:-${legacy_templates_dir}/cluster-legacy-params.yaml}"
+tmpl_external_cluster_legacy="${EXTERNAL_CLUSTER_LEGACY_TEMPLATE:-${legacy_templates_dir}/external-cluster-legacy.yaml}"
+tmpl_scheduledbackup_legacy="${SCHEDULEDBACKUP_LEGACY_TEMPLATE:-${legacy_templates_dir}/scheduledbackup-legacy.yaml}"
 
 # Check whether a CRD exists in the given cluster context
 check_crd_existence() {
@@ -150,13 +164,13 @@ kubectl_apply() {
 generate_objectstore_yaml() {
     local region="$1"
     REGION="${region}" \
-    envsubst '${REGION}' < "${templates_dir}/objectstore.yaml"
+    envsubst '${REGION}' < "${tmpl_objectstore}"
 }
 
 generate_podmonitor_yaml() {
     local region="$1"
     REGION="${region}" \
-    envsubst '${REGION}' < "${templates_dir}/podmonitor.yaml"
+    envsubst '${REGION}' < "${tmpl_podmonitor}"
 }
 
 # Emit a Cluster + ScheduledBackup stream using the Barman Cloud Plugin
@@ -167,36 +181,36 @@ generate_cluster_yaml_plugin() {
 
     # Cluster header: apiVersion through affinity
     REGION="${region}" POSTGRESQL_IMAGE="${POSTGRESQL_IMAGE}" \
-    envsubst '${REGION} ${POSTGRESQL_IMAGE}' < "${templates_dir}/cluster-header.yaml"
+    envsubst '${REGION} ${POSTGRESQL_IMAGE}' < "${tmpl_cluster}"
 
     # Bootstrap: initdb for the primary (or single-region); recovery for replicas
     if [ "${region}" = "${primary_region}" ] || [ "${num_regions}" -eq 1 ]; then
-        cat "${templates_dir}/bootstrap-initdb.yaml"
+        cat "${tmpl_bootstrap_initdb}"
     else
         PRIMARY_REGION="${primary_region}" \
-        envsubst '${PRIMARY_REGION}' < "${templates_dir}/bootstrap-recovery.yaml"
+        envsubst '${PRIMARY_REGION}' < "${tmpl_bootstrap_recovery}"
     fi
 
     # PostgreSQL parameters and Barman Cloud Plugin configuration
     REGION="${region}" \
-    envsubst '${REGION}' < "${templates_dir}/cluster-plugin-params.yaml"
+    envsubst '${REGION}' < "${tmpl_cluster_plugin_params}"
 
     # Distributed topology replica section — only for multi-region setups
     if [ "${num_regions}" -gt 1 ]; then
         REGION="${region}" PRIMARY_REGION="${primary_region}" SOURCE_REGION="${source_region}" \
-        envsubst '${REGION} ${PRIMARY_REGION} ${SOURCE_REGION}' < "${templates_dir}/replica-section.yaml"
+        envsubst '${REGION} ${PRIMARY_REGION} ${SOURCE_REGION}' < "${tmpl_replica_section}"
     fi
 
     # External cluster references — one entry per region
     printf '  externalClusters:\n'
     local r
     for r in "${REGIONS[@]}"; do
-        REGION="${r}" envsubst '${REGION}' < "${templates_dir}/external-cluster-plugin.yaml"
+        REGION="${r}" envsubst '${REGION}' < "${tmpl_external_cluster_plugin}"
     done
 
     # ScheduledBackup document
     REGION="${region}" \
-    envsubst '${REGION}' < "${templates_dir}/scheduledbackup-plugin.yaml"
+    envsubst '${REGION}' < "${tmpl_scheduledbackup_plugin}"
 }
 
 # Emit a Cluster + ScheduledBackup stream using in-tree (legacy) Barman configuration
@@ -206,31 +220,31 @@ generate_cluster_yaml_legacy() {
     source_region=$(get_source_region "${region}")
 
     REGION="${region}" POSTGRESQL_IMAGE="${POSTGRESQL_LEGACY_IMAGE}" \
-    envsubst '${REGION} ${POSTGRESQL_IMAGE}' < "${templates_dir}/cluster-header.yaml"
+    envsubst '${REGION} ${POSTGRESQL_IMAGE}' < "${tmpl_cluster}"
 
     if [ "${region}" = "${primary_region}" ] || [ "${num_regions}" -eq 1 ]; then
-        cat "${templates_dir}/bootstrap-initdb.yaml"
+        cat "${tmpl_bootstrap_initdb}"
     else
         PRIMARY_REGION="${primary_region}" \
-        envsubst '${PRIMARY_REGION}' < "${templates_dir}/bootstrap-recovery.yaml"
+        envsubst '${PRIMARY_REGION}' < "${tmpl_bootstrap_recovery}"
     fi
 
     REGION="${region}" \
-    envsubst '${REGION}' < "${legacy_templates_dir}/cluster-legacy-params.yaml"
+    envsubst '${REGION}' < "${tmpl_cluster_legacy_params}"
 
     if [ "${num_regions}" -gt 1 ]; then
         REGION="${region}" PRIMARY_REGION="${primary_region}" SOURCE_REGION="${source_region}" \
-        envsubst '${REGION} ${PRIMARY_REGION} ${SOURCE_REGION}' < "${templates_dir}/replica-section.yaml"
+        envsubst '${REGION} ${PRIMARY_REGION} ${SOURCE_REGION}' < "${tmpl_replica_section}"
     fi
 
     printf '  externalClusters:\n'
     local r
     for r in "${REGIONS[@]}"; do
-        REGION="${r}" envsubst '${REGION}' < "${legacy_templates_dir}/external-cluster-legacy.yaml"
+        REGION="${r}" envsubst '${REGION}' < "${tmpl_external_cluster_legacy}"
     done
 
     REGION="${region}" \
-    envsubst '${REGION}' < "${legacy_templates_dir}/scheduledbackup-legacy.yaml"
+    envsubst '${REGION}' < "${tmpl_scheduledbackup_legacy}"
 }
 
 # ---------------------------------------------------------------------------

--- a/demo/templates/cluster-plugin-params.yaml
+++ b/demo/templates/cluster-plugin-params.yaml
@@ -1,16 +1,3 @@
-  postgresql:
-    # See https://cloudnative-pg.io/documentation/current/postgresql_conf/#the-postgresql-section
-    parameters:
-      max_connections: '100'
-      log_checkpoints: 'on'
-      log_lock_waits: 'on'
-      pg_stat_statements.max: '10000'
-      pg_stat_statements.track: 'all'
-      hot_standby_feedback: 'on'
-      # Container images work fine with sysv shared memory
-      shared_memory_type: 'sysv'
-      dynamic_shared_memory_type: 'sysv'
-
   plugins:
   - name: barman-cloud.cloudnative-pg.io
     isWALArchiver: true

--- a/demo/templates/cluster.yaml
+++ b/demo/templates/cluster.yaml
@@ -25,3 +25,16 @@ spec:
     topologyKey: kubernetes.io/hostname
     podAntiAffinityType: required
 
+  postgresql:
+    # See https://cloudnative-pg.io/documentation/current/postgresql_conf/#the-postgresql-section
+    parameters:
+      max_connections: '100'
+      log_checkpoints: 'on'
+      log_lock_waits: 'on'
+      pg_stat_statements.max: '10000'
+      pg_stat_statements.track: 'all'
+      hot_standby_feedback: 'on'
+      # Container images work fine with sysv shared memory
+      shared_memory_type: 'sysv'
+      dynamic_shared_memory_type: 'sysv'
+


### PR DESCRIPTION
Rename `demo/templates/cluster-header.yaml` to `cluster.yaml` for clarity.

Introduce `TEMPLATES_DIR` to replace the entire templates directory, and twelve per-file overrides (`CLUSTER_TEMPLATE`, `BOOTSTRAP_INITDB_TEMPLATE`, `BOOTSTRAP_RECOVERY_TEMPLATE`, `CLUSTER_PLUGIN_PARAMS_TEMPLATE`, `REPLICA_SECTION_TEMPLATE`, `EXTERNAL_CLUSTER_PLUGIN_TEMPLATE`, `SCHEDULEDBACKUP_PLUGIN_TEMPLATE`, `OBJECTSTORE_TEMPLATE`, `PODMONITOR_TEMPLATE`, `CLUSTER_LEGACY_PARAMS_TEMPLATE`, `EXTERNAL_CLUSTER_LEGACY_TEMPLATE`, `SCHEDULEDBACKUP_LEGACY_TEMPLATE`) to replace individual fragments. Both levels compose: `TEMPLATES_DIR` sets the base; per-file vars override specific fragments within it.

Document the template customisation options in `demo/README.md`.

Assisted-by: Claude Sonnet 4.6