### PR TITLE
refactor: remove git dependency for repository root detection

### DIFF
--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -37,13 +37,11 @@
 set -eu
 [[ "${DEBUG:-false}" == "true" ]] && set -x
 
-git_repo_root=$(git rev-parse --show-toplevel)
-
 # Source the common setup script
-source "${git_repo_root}/scripts/common.sh"
+source "$(cd "$(dirname "$0")/.." && pwd)/scripts/common.sh"
 
-kube_config_path="${git_repo_root}/k8s/kube-config.yaml"
-templates_dir="${TEMPLATES_DIR:-${git_repo_root}/demo/templates}"
+kube_config_path="${KUBE_CONFIG_PATH}"
+templates_dir="${TEMPLATES_DIR:-${REPO_ROOT}/demo/templates}"
 legacy_templates_dir="${templates_dir}/legacy"
 
 # Default PostgreSQL image (overridable via env var)
@@ -251,7 +249,7 @@ generate_cluster_yaml_legacy() {
 # Deployment
 # ---------------------------------------------------------------------------
 
-cd "${git_repo_root}"
+cd "${REPO_ROOT}"
 export KUBECONFIG="${kube_config_path}"
 
 total_start=$SECONDS

--- a/demo/teardown.sh
+++ b/demo/teardown.sh
@@ -28,15 +28,13 @@
 set -u
 [[ "${DEBUG:-false}" == "true" ]] && set -x
 
-git_repo_root=$(git rev-parse --show-toplevel)
-
 # Source the common setup script
-source "${git_repo_root}/scripts/common.sh"
+source "$(cd "$(dirname "$0")/.." && pwd)/scripts/common.sh"
 
-kube_config_path="${git_repo_root}/k8s/kube-config.yaml"
+kube_config_path="${KUBE_CONFIG_PATH}"
 
 # Setup a separate Kubeconfig
-cd "${git_repo_root}"
+cd "${REPO_ROOT}"
 export KUBECONFIG="${kube_config_path}"
 
 # Detect or use the provided regions

--- a/monitoring/setup.sh
+++ b/monitoring/setup.sh
@@ -28,7 +28,7 @@
 #
 
 # Source the common setup script
-source $(git rev-parse --show-toplevel)/scripts/common.sh
+source "$(cd "$(dirname "$0")/.." && pwd)/scripts/common.sh"
 
 # --- Main Logic ---
 # Determine regions from arguments, or auto-detect if none are provided
@@ -47,11 +47,11 @@ for region in "${REGIONS[@]}"; do
 
 # Deploy the Prometheus operator in the playground Kubernetes clusters
     kubectl --context ${CONTEXT_NAME} create ns prometheus-operator || true
-    kubectl kustomize ${GIT_REPO_ROOT}/monitoring/prometheus-operator | \
+    kubectl kustomize ${REPO_ROOT}/monitoring/prometheus-operator | \
       kubectl --context ${CONTEXT_NAME} apply --force-conflicts --server-side -f -
 
 # We make sure that monitoring workloads are deployed in the infrastructure node.
-    kubectl kustomize ${GIT_REPO_ROOT}/monitoring/prometheus-instance | \
+    kubectl kustomize ${REPO_ROOT}/monitoring/prometheus-instance | \
         kubectl --context=${CONTEXT_NAME} apply --force-conflicts --server-side -f -
     kubectl --context=${CONTEXT_NAME} -n prometheus-operator \
       patch deployment prometheus-operator \
@@ -71,7 +71,7 @@ for region in "${REGIONS[@]}"; do
       --patch='{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/infra","operator":"Exists","effect":"NoSchedule"}],"nodeSelector":{"node-role.kubernetes.io/infra":""}}}}}'
 
 # Creating Grafana instance and dashboards
-    kubectl kustomize ${GIT_REPO_ROOT}/monitoring/grafana/ | \
+    kubectl kustomize ${REPO_ROOT}/monitoring/grafana/ | \
       kubectl --context ${CONTEXT_NAME} apply -f -
 
 # Restart the operator

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -38,7 +38,7 @@ RUSTFS_ROOT_USER="${RUSTFS_ROOT_USER:-cnpg}"
 RUSTFS_ROOT_PASSWORD="${RUSTFS_ROOT_PASSWORD:-Cl0udNativePGRocks}"
 
 # --- Common Prerequisite Checks ---
-REQUIRED_COMMANDS="kind kubectl git grep sed"
+REQUIRED_COMMANDS="kind kubectl grep sed"
 for cmd in $REQUIRED_COMMANDS; do
     if ! command -v "$cmd" &> /dev/null; then
         echo "❌ Error: Missing required command: $cmd"
@@ -62,8 +62,7 @@ if [ -z "${CONTAINER_PROVIDER:-}" ]; then
 fi
 
 # Determine project root and kubeconfig path
-GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
-KUBE_CONFIG_PATH="${GIT_REPO_ROOT}/k8s/kube-config.yaml"
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+KUBE_CONFIG_PATH="${REPO_ROOT}/k8s/kube-config.yaml"
 
-# source funcs_regions.sh
-source $(git rev-parse --show-toplevel)/scripts/funcs_regions.sh
+source "${REPO_ROOT}/scripts/funcs_regions.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,8 +69,8 @@ set_regions "$@"
 # Setup a single, shared Kubeconfig for all clusters
 export KUBECONFIG="${KUBE_CONFIG_PATH}"
 > "${KUBE_CONFIG_PATH}" # Create or clear the kubeconfig file
-cd "${GIT_REPO_ROOT}"
-kind_config_path="${GIT_REPO_ROOT}/k8s/kind-cluster.yaml"
+cd "${REPO_ROOT}"
+kind_config_path="${REPO_ROOT}/k8s/kind-cluster.yaml"
 
 # --- Phase 1: Provision Clusters and RustFS Instances ---
 let "current_objectstore_port = RUSTFS_BASE_PORT"


### PR DESCRIPTION
Replace `git rev-parse --show-toplevel` with `BASH_SOURCE`/`dirname`-based path resolution in `scripts/common.sh`. Rename `GIT_REPO_ROOT` to `REPO_ROOT` across all scripts and drop `git` from `REQUIRED_COMMANDS`.

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>