### PR TITLE
chore: add Renovate and pin all dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,3 @@
 
 # Go workspace file
 go.work
-
-# Claude Code instructions (local only)
-CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 # Go workspace file
 go.work
+
+# Claude Code instructions (local only)
+CLAUDE.md

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -280,11 +280,9 @@ for region in "${REGIONS[@]}"; do
                 kubectl --context "${CONTEXT_NAME}" apply -f - --server-side
         else
             # Deploy CloudNativePG operator (latest stable release)
-            cnpg_ver="${CNPG_VERSION#v}"
-            cnpg_minor=$(printf '%s' "${cnpg_ver}" | cut -d. -f1,2)
             kubectl apply --server-side \
                 --context "${CONTEXT_NAME}" \
-                -f "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${cnpg_minor}/releases/cnpg-${cnpg_ver}.yaml"
+                -f "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${CNPG_RELEASE_BRANCH}/releases/cnpg-${CNPG_VERSION_BARE}.yaml"
         fi
 
         # Wait for CNPG deployment to complete

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -279,9 +279,12 @@ for region in "${REGIONS[@]}"; do
                 https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml | \
                 kubectl --context "${CONTEXT_NAME}" apply -f - --server-side
         else
-            # Deploy CloudNativePG operator (latest version, through the plugin)
-            kubectl cnpg install generate --control-plane | \
-                kubectl --context "${CONTEXT_NAME}" apply -f - --server-side
+            # Deploy CloudNativePG operator (latest stable release)
+            cnpg_ver="${CNPG_VERSION#v}"
+            cnpg_minor=$(printf '%s' "${cnpg_ver}" | cut -d. -f1,2)
+            kubectl apply --server-side \
+                --context "${CONTEXT_NAME}" \
+                -f "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${cnpg_minor}/releases/cnpg-${cnpg_ver}.yaml"
         fi
 
         # Wait for CNPG deployment to complete
@@ -292,7 +295,7 @@ for region in "${REGIONS[@]}"; do
 
         # Deploy cert-manager
         kubectl apply --context "${CONTEXT_NAME}" -f \
-            https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+            "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
         # Wait for cert-manager deployment to complete
         kubectl rollout --context "${CONTEXT_NAME}" status deployment \
@@ -308,7 +311,7 @@ for region in "${REGIONS[@]}"; do
         else
             # Deploy Barman Cloud Plugin (latest stable)
             kubectl apply --context "${CONTEXT_NAME}" -f \
-                https://github.com/cloudnative-pg/plugin-barman-cloud/releases/latest/download/manifest.yaml
+                "https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/${BARMAN_CLOUD_PLUGIN_VERSION}/manifest.yaml"
         fi
 
         # Wait for Barman Cloud Plugin deployment to complete

--- a/demo/teardown.sh
+++ b/demo/teardown.sh
@@ -61,15 +61,17 @@ for region in "${REGIONS[@]}"; do
 
     # Delete Barman Cloud Plugin
     kubectl delete --context "${CONTEXT_NAME}" --ignore-not-found=true -f \
-        https://github.com/cloudnative-pg/plugin-barman-cloud/releases/latest/download/manifest.yaml
+        "https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/${BARMAN_CLOUD_PLUGIN_VERSION}/manifest.yaml"
 
     # Delete cert-manager
     kubectl delete --context "${CONTEXT_NAME}" --ignore-not-found=true -f \
-        https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+        "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
     # Delete CNPG operator
-    kubectl cnpg install generate --control-plane | \
-        kubectl --context "${CONTEXT_NAME}" delete --ignore-not-found=true -f -
+    cnpg_ver="${CNPG_VERSION#v}"
+    cnpg_minor=$(printf '%s' "${cnpg_ver}" | cut -d. -f1,2)
+    kubectl delete --context "${CONTEXT_NAME}" --ignore-not-found=true -f \
+        "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${cnpg_minor}/releases/cnpg-${cnpg_ver}.yaml"
 
     # Remove backup data from the object store container
     ${CONTAINER_PROVIDER} exec objectstore-${region} rm -rf /data/backups/pg-${region}

--- a/demo/teardown.sh
+++ b/demo/teardown.sh
@@ -68,10 +68,8 @@ for region in "${REGIONS[@]}"; do
         "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
     # Delete CNPG operator
-    cnpg_ver="${CNPG_VERSION#v}"
-    cnpg_minor=$(printf '%s' "${cnpg_ver}" | cut -d. -f1,2)
     kubectl delete --context "${CONTEXT_NAME}" --ignore-not-found=true -f \
-        "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${cnpg_minor}/releases/cnpg-${cnpg_ver}.yaml"
+        "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${CNPG_RELEASE_BRANCH}/releases/cnpg-${CNPG_VERSION_BARE}.yaml"
 
     # Remove backup data from the object store container
     ${CONTAINER_PROVIDER} exec objectstore-${region} rm -rf /data/backups/pg-${region}

--- a/monitoring/prometheus-operator/kustomization.yaml
+++ b/monitoring/prometheus-operator/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/prometheus-operator/prometheus-operator/
+ - https://github.com/prometheus-operator/prometheus-operator/?ref=v0.90.1
 namespace: prometheus-operator

--- a/monitoring/setup.sh
+++ b/monitoring/setup.sh
@@ -64,7 +64,7 @@ for region in "${REGIONS[@]}"; do
 
 # Deploying Grafana operator
     kubectl --context ${CONTEXT_NAME} apply --force-conflicts --server-side \
-      -f https://github.com/grafana/grafana-operator/releases/latest/download/kustomize-cluster_scoped.yaml
+      -f "https://github.com/grafana/grafana-operator/releases/download/${GRAFANA_OPERATOR_VERSION}/kustomize-cluster_scoped.yaml"
     kubectl --context ${CONTEXT_NAME} -n grafana \
       patch deployment grafana-operator-controller-manager \
       --type='merge' \

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "**/out/**"
+  ],
+  "regexManagers": [
+    {
+      "description": "Version variables in shell scripts annotated with # renovate comments",
+      "fileMatch": ["(^|/)[^/]*\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n[A-Z_]+=\"\\$\\{[A-Z_]+:-(?<currentValue>[^\"]+)\\}\""
+      ],
+      "versioningTemplate": "semver-coerced"
+    },
+    {
+      "description": "GitHub refs in kustomization.yaml resources",
+      "fileMatch": ["(^|/)kustomization\\.yaml$"],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>[^/?]+/[^/?]+)[^?]*\\?ref=(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -6,22 +6,43 @@
   "ignorePaths": [
     "**/out/**"
   ],
-  "regexManagers": [
+  "automerge": false,
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "customManagers": [
     {
+      "customType": "regex",
       "description": "Version variables in shell scripts annotated with # renovate comments",
       "fileMatch": ["(^|/)[^/]*\\.sh$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n[A-Z_]+=\"\\$\\{[A-Z_]+:-(?<currentValue>[^\"]+)\\}\""
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n\\s*[A-Z0-9_]+=\"\\$\\{[A-Z0-9_]+:-(?<currentValue>[^\"]+)\\}\""
       ],
       "versioningTemplate": "semver-coerced"
     },
     {
+      "customType": "regex",
       "description": "GitHub refs in kustomization.yaml resources",
       "fileMatch": ["(^|/)kustomization\\.yaml$"],
       "matchStrings": [
         "https://github\\.com/(?<depName>[^/?]+/[^/?]+)[^?]*\\?ref=(?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "CNPG release branches only exist for GA versions; skip pre-releases",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["cloudnative-pg/cloudnative-pg"],
+      "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
+      "description": "RustFS: stay on the beta track or move to GA, never to alpha",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["rustfs/rustfs"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-beta\\.\\d+)?$/"
     }
   ]
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -72,6 +72,9 @@ KUBE_CONFIG_PATH="${REPO_ROOT}/k8s/kube-config.yaml"
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.2}"
 # renovate: datasource=github-releases depName=cloudnative-pg/cloudnative-pg
 CNPG_VERSION="${CNPG_VERSION:-v1.29.0}"
+# Derived: bare version and release branch suffix (e.g. v1.29.0 -> 1.29.0, 1.29)
+CNPG_VERSION_BARE="${CNPG_VERSION#v}"
+CNPG_RELEASE_BRANCH="${CNPG_VERSION_BARE%.*}"
 # renovate: datasource=github-releases depName=cloudnative-pg/plugin-barman-cloud
 BARMAN_CLOUD_PLUGIN_VERSION="${BARMAN_CLOUD_PLUGIN_VERSION:-v0.12.0}"
 # renovate: datasource=github-releases depName=grafana/grafana-operator

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -31,7 +31,9 @@ K8S_CONTEXT_PREFIX=${K8S_CONTEXT_PREFIX-kind-}
 K8S_BASE_NAME=${K8S_NAME-k8s-}
 
 # RustFS Configuration
-RUSTFS_IMAGE="${RUSTFS_IMAGE:-rustfs/rustfs:latest}"
+# renovate: datasource=docker depName=rustfs/rustfs
+RUSTFS_VERSION="${RUSTFS_VERSION:-1.0.0-beta.1}"
+RUSTFS_IMAGE="${RUSTFS_IMAGE:-rustfs/rustfs:${RUSTFS_VERSION}}"
 RUSTFS_BASE_NAME="${RUSTFS_BASE_NAME:-objectstore}"
 RUSTFS_BASE_PORT=${RUSTFS_BASE_PORT:-9001}
 RUSTFS_ROOT_USER="${RUSTFS_ROOT_USER:-cnpg}"
@@ -64,5 +66,15 @@ fi
 # Determine project root and kubeconfig path
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 KUBE_CONFIG_PATH="${REPO_ROOT}/k8s/kube-config.yaml"
+
+# Demo deployment versions
+# renovate: datasource=github-releases depName=cert-manager/cert-manager
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.2}"
+# renovate: datasource=github-releases depName=cloudnative-pg/cloudnative-pg
+CNPG_VERSION="${CNPG_VERSION:-v1.29.0}"
+# renovate: datasource=github-releases depName=cloudnative-pg/plugin-barman-cloud
+BARMAN_CLOUD_PLUGIN_VERSION="${BARMAN_CLOUD_PLUGIN_VERSION:-v0.12.0}"
+# renovate: datasource=github-releases depName=grafana/grafana-operator
+GRAFANA_OPERATOR_VERSION="${GRAFANA_OPERATOR_VERSION:-v5.22.2}"
 
 source "${REPO_ROOT}/scripts/funcs_regions.sh"


### PR DESCRIPTION
Replace all `latest` and unversioned references with pinned versions managed by Renovate. Add `renovate.json` with two `customManagers` rules: one that tracks `# renovate:` annotations in `.sh` files, and one that tracks GitHub `?ref=` URLs in `kustomization.yaml` files; alongside the built-in nix manager.

Pinned versions (all overridable via env vars):
- `RUSTFS_VERSION` → `1.0.0-beta.1` (Docker Hub)
- `CERT_MANAGER_VERSION` → `v1.20.2` (GitHub releases)
- `CNPG_VERSION` → `v1.29.0` (GitHub releases)
- `BARMAN_CLOUD_PLUGIN_VERSION` → `v0.12.0` (GitHub releases)
- `GRAFANA_OPERATOR_VERSION` → `v5.22.2` (GitHub releases)
- prometheus-operator kustomize ref → `v0.90.1`

Replace `kubectl cnpg install generate --control-plane` with a direct versioned URL install for the stable CNPG operator, enabling Renovate to track and bump `CNPG_VERSION` automatically. The released manifest has no scheduling constraints, so the operator lands on `infra` or `app` worker nodes, as postgres nodes carry a `NoSchedule` taint.

Closes #60

Assisted-by: Claude