### PR TITLE
feat: pin CNPG operator to the control-plane node

### DIFF
--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -285,6 +285,14 @@ for region in "${REGIONS[@]}"; do
                 -f "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${CNPG_RELEASE_BRANCH}/releases/cnpg-${CNPG_VERSION_BARE}.yaml"
         fi
 
+        # Pin the operator to the control-plane node. The playground taints the
+        # postgres nodes and reserves infra/app nodes for workloads, so the
+        # control-plane is the natural home for the operator in this demo.
+        kubectl --context "${CONTEXT_NAME}" -n cnpg-system \
+            patch deployment cnpg-controller-manager \
+            --type='merge' \
+            --patch='{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]}]}}},"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]}}}}'
+
         # Wait for CNPG deployment to complete
         kubectl --context "${CONTEXT_NAME}" rollout status deployment \
             -n cnpg-system cnpg-controller-manager


### PR DESCRIPTION
## What

Patch the `cnpg-controller-manager` deployment in `demo/setup.sh` so the operator runs on the **control-plane node**, adding a required `nodeAffinity` on `node-role.kubernetes.io/control-plane` plus a matching toleration.

## Why

The playground taints the `postgres` nodes and reserves the `infra`/`app` nodes for workloads, so the control-plane is the natural home for the operator in this demo.

## Notes

- Applied in both stable and `TRUNK=true` modes, before the `rollout status` wait.
- Only runs in the live path — `DRY_RUN`/`OUTPUT_DIR` runs are unaffected.
- Follows the `kubectl patch` convention already used in `monitoring/setup.sh`.