### PR TITLE
feat: deploy CSI hostpath driver with volume snapshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ override the default playground configuration:
 | `RUSTFS_BASE_PORT` | `9001` | Host port for the first RustFS console; increments by one per region |
 | `K8S_NAME` | `k8s-` | Base name used when creating Kind clusters |
 | `K8S_CONTEXT_PREFIX` | `kind-` | Prefix added to Kind cluster names to form kubectl context names |
+| `DEPLOY_CSI_HOSTPATH` | `true` | Deploy the CSI hostpath driver + volume snapshot support in every region |
 
 Example:
 
@@ -150,6 +151,39 @@ In this example:
 - Worker nodes have different roles, such as `infra` for infrastructure, `app`
   for application workloads, and `postgres` for PostgreSQL databases. Each node
   runs Kubernetes version `v1.34.0`.
+
+### Volume Snapshots
+
+Each region ships with the [CSI hostpath driver](https://github.com/kubernetes-csi/csi-driver-host-path)
+and volume snapshot support, so you can experiment with CloudNativePG's
+snapshot-based backup and recovery.
+
+The driver uses its *distributed* mode: it runs on each `postgres`-role node
+(one DaemonSet pod per node) and provisions volumes locally, so the three
+PostgreSQL instances keep their spread across separate nodes while each instance
+gets node-local storage that can be snapshotted independently. It exposes a
+`csi-hostpath-fast` StorageClass (with `volumeBindingMode: WaitForFirstConsumer`)
+and a default `csi-hostpath-snapclass` VolumeSnapshotClass.
+
+The demo PostgreSQL clusters use `csi-hostpath-fast` by default (override with
+`STORAGE_CLASS` when running `demo/setup.sh`; set `STORAGE_CLASS=""` to use each
+cluster's default StorageClass). Kind's `standard` (local-path) class remains the
+cluster default and is not modified.
+
+When the clusters run on `csi-hostpath-fast`, `demo/setup.sh` also configures
+`spec.backup.volumeSnapshot` with the `csi-hostpath-snapclass` VolumeSnapshotClass
+(WAL archiving stays on the object store for point-in-time recovery). You can take
+a snapshot-based backup on demand with:
+
+```bash
+kubectl cnpg backup pg-eu --method volumeSnapshot
+```
+
+To skip this and keep the clusters on `standard` local-path storage only, run:
+
+```bash
+DEPLOY_CSI_HOSTPATH=false ./scripts/setup.sh
+```
 
 ### Cleaning Up the Environment
 

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -48,6 +48,22 @@ legacy_templates_dir="${templates_dir}/legacy"
 POSTGRESQL_IMAGE="${POSTGRESQL_IMAGE:-ghcr.io/cloudnative-pg/postgresql:18-standard-trixie}"
 POSTGRESQL_LEGACY_IMAGE="${POSTGRESQL_LEGACY_IMAGE:-ghcr.io/cloudnative-pg/postgresql:18-system-trixie}"
 
+# StorageClass for the PostgreSQL clusters. Defaults to the CSI hostpath class
+# deployed by scripts/setup.sh (node-local storage with volume snapshot support).
+# Set STORAGE_CLASS="" to use each cluster's default StorageClass instead.
+STORAGE_CLASS="${STORAGE_CLASS-${CSI_STORAGE_CLASS:-csi-hostpath-fast}}"
+
+# VolumeSnapshotClass for snapshot-based backups. Only meaningful when the
+# clusters use the CSI hostpath StorageClass (the class shipped with the driver);
+# with any other/default StorageClass there is no snapshot-capable storage, so the
+# backup.volumeSnapshot block is omitted. Set VOLUME_SNAPSHOT_CLASS="" to disable,
+# or to a custom VolumeSnapshotClass name.
+if [ -n "${STORAGE_CLASS}" ] && [ "${STORAGE_CLASS}" = "${CSI_STORAGE_CLASS:-csi-hostpath-fast}" ]; then
+    VOLUME_SNAPSHOT_CLASS="${VOLUME_SNAPSHOT_CLASS-csi-hostpath-snapclass}"
+else
+    VOLUME_SNAPSHOT_CLASS="${VOLUME_SNAPSHOT_CLASS-}"
+fi
+
 # Template file overrides — set any of these to replace the corresponding built-in fragment
 tmpl_cluster="${CLUSTER_TEMPLATE:-${templates_dir}/cluster.yaml}"
 tmpl_bootstrap_initdb="${BOOTSTRAP_INITDB_TEMPLATE:-${templates_dir}/bootstrap-initdb.yaml}"
@@ -56,6 +72,7 @@ tmpl_cluster_plugin_params="${CLUSTER_PLUGIN_PARAMS_TEMPLATE:-${templates_dir}/c
 tmpl_replica_section="${REPLICA_SECTION_TEMPLATE:-${templates_dir}/replica-section.yaml}"
 tmpl_external_cluster_plugin="${EXTERNAL_CLUSTER_PLUGIN_TEMPLATE:-${templates_dir}/external-cluster-plugin.yaml}"
 tmpl_scheduledbackup_plugin="${SCHEDULEDBACKUP_PLUGIN_TEMPLATE:-${templates_dir}/scheduledbackup-plugin.yaml}"
+tmpl_backup_volumesnapshot="${BACKUP_VOLUMESNAPSHOT_TEMPLATE:-${templates_dir}/backup-volumesnapshot.yaml}"
 tmpl_objectstore="${OBJECTSTORE_TEMPLATE:-${templates_dir}/objectstore.yaml}"
 tmpl_podmonitor="${PODMONITOR_TEMPLATE:-${templates_dir}/podmonitor.yaml}"
 tmpl_cluster_legacy_params="${CLUSTER_LEGACY_PARAMS_TEMPLATE:-${legacy_templates_dir}/cluster-legacy-params.yaml}"
@@ -154,8 +171,9 @@ kubectl_apply() {
 # ---------------------------------------------------------------------------
 # YAML generators — each function writes a complete YAML stream to stdout.
 # The caller is responsible for piping to kubectl.
-# Template files use ${REGION}, ${PRIMARY_REGION}, ${SOURCE_REGION}, and
-# ${POSTGRESQL_IMAGE} as placeholders; envsubst substitutes only those
+# Template files use ${REGION}, ${PRIMARY_REGION}, ${SOURCE_REGION},
+# ${POSTGRESQL_IMAGE}, ${STORAGE_CLASS}, and ${VOLUME_SNAPSHOT_CLASS} as
+# placeholders; envsubst substitutes only those
 # variables (explicit list prevents accidental expansion of env vars).
 # ---------------------------------------------------------------------------
 
@@ -178,8 +196,8 @@ generate_cluster_yaml_plugin() {
     source_region=$(get_source_region "${region}")
 
     # Cluster header: apiVersion through affinity
-    REGION="${region}" POSTGRESQL_IMAGE="${POSTGRESQL_IMAGE}" \
-    envsubst '${REGION} ${POSTGRESQL_IMAGE}' < "${tmpl_cluster}"
+    REGION="${region}" POSTGRESQL_IMAGE="${POSTGRESQL_IMAGE}" STORAGE_CLASS="${STORAGE_CLASS}" \
+    envsubst '${REGION} ${POSTGRESQL_IMAGE} ${STORAGE_CLASS}' < "${tmpl_cluster}"
 
     # Bootstrap: initdb for the primary (or single-region); recovery for replicas
     if [ "${region}" = "${primary_region}" ] || [ "${num_regions}" -eq 1 ]; then
@@ -192,6 +210,14 @@ generate_cluster_yaml_plugin() {
     # PostgreSQL parameters and Barman Cloud Plugin configuration
     REGION="${region}" \
     envsubst '${REGION}' < "${tmpl_cluster_plugin_params}"
+
+    # Volume snapshot backup config (only when using snapshot-capable storage).
+    # Plugin mode has no spec.backup otherwise, so open it here.
+    if [ -n "${VOLUME_SNAPSHOT_CLASS}" ]; then
+        printf '  backup:\n'
+        VOLUME_SNAPSHOT_CLASS="${VOLUME_SNAPSHOT_CLASS}" \
+        envsubst '${VOLUME_SNAPSHOT_CLASS}' < "${tmpl_backup_volumesnapshot}"
+    fi
 
     # Distributed topology replica section — only for multi-region setups
     if [ "${num_regions}" -gt 1 ]; then
@@ -217,8 +243,8 @@ generate_cluster_yaml_legacy() {
     local source_region
     source_region=$(get_source_region "${region}")
 
-    REGION="${region}" POSTGRESQL_IMAGE="${POSTGRESQL_LEGACY_IMAGE}" \
-    envsubst '${REGION} ${POSTGRESQL_IMAGE}' < "${tmpl_cluster}"
+    REGION="${region}" POSTGRESQL_IMAGE="${POSTGRESQL_LEGACY_IMAGE}" STORAGE_CLASS="${STORAGE_CLASS}" \
+    envsubst '${REGION} ${POSTGRESQL_IMAGE} ${STORAGE_CLASS}' < "${tmpl_cluster}"
 
     if [ "${region}" = "${primary_region}" ] || [ "${num_regions}" -eq 1 ]; then
         cat "${tmpl_bootstrap_initdb}"
@@ -229,6 +255,14 @@ generate_cluster_yaml_legacy() {
 
     REGION="${region}" \
     envsubst '${REGION}' < "${tmpl_cluster_legacy_params}"
+
+    # Volume snapshot backup config (only when using snapshot-capable storage).
+    # Legacy mode already opened spec.backup above, so this appends volumeSnapshot
+    # as a sibling of barmanObjectStore — it MUST stay adjacent to the params above.
+    if [ -n "${VOLUME_SNAPSHOT_CLASS}" ]; then
+        VOLUME_SNAPSHOT_CLASS="${VOLUME_SNAPSHOT_CLASS}" \
+        envsubst '${VOLUME_SNAPSHOT_CLASS}' < "${tmpl_backup_volumesnapshot}"
+    fi
 
     if [ "${num_regions}" -gt 1 ]; then
         REGION="${region}" PRIMARY_REGION="${primary_region}" SOURCE_REGION="${source_region}" \

--- a/demo/templates/backup-volumesnapshot.yaml
+++ b/demo/templates/backup-volumesnapshot.yaml
@@ -1,0 +1,7 @@
+    # Volume snapshot backups using the CSI hostpath driver's VolumeSnapshotClass.
+    # WAL archiving stays on the object store (Barman plugin / in-tree), so this
+    # enables snapshot-based base backups with object-store WAL for PITR. Take one
+    # on demand with: kubectl cnpg backup <cluster> -m volumeSnapshot
+    volumeSnapshot:
+      className: ${VOLUME_SNAPSHOT_CLASS}
+      online: true

--- a/demo/templates/cluster.yaml
+++ b/demo/templates/cluster.yaml
@@ -7,10 +7,15 @@ spec:
   imageName: ${POSTGRESQL_IMAGE}
 
   storage:
+    # Node-local storage backed by the CSI hostpath driver, so each instance can
+    # be backed up and restored via volume snapshots. Leave STORAGE_CLASS empty
+    # to fall back to the cluster's default StorageClass.
+    storageClass: ${STORAGE_CLASS}
     size: 1Gi
 
   # See https://cloudnative-pg.io/documentation/current/storage/#volume-for-wal
   walStorage:
+    storageClass: ${STORAGE_CLASS}
     size: 1Gi
 
   # See https://cloudnative-pg.io/documentation/current/scheduling/#isolating-postgresql-workloads

--- a/k8s/csi-hostpath/csi-hostpath-plugin-patch.yaml
+++ b/k8s/csi-hostpath/csi-hostpath-plugin-patch.yaml
@@ -1,0 +1,52 @@
+##
+## Strategic-merge patch applied to the upstream distributed node plugin
+## DaemonSet (kubernetes-csi/csi-driver-host-path, kubernetes-distributed).
+##
+## Three deltas, none of which the upstream distributed deployment provides:
+##   1. A csi-snapshotter sidecar in node-deployment (distributed snapshotting)
+##      mode, so every node manages snapshots for its own local volumes. It shares
+##      the pod's csi-provisioner ServiceAccount (see csi-hostpath-rbac.yaml).
+##   2. A nodeSelector + toleration pinning the driver to the postgres-role nodes,
+##      where PostgreSQL (and therefore its node-local volumes) lives. Without this
+##      the DaemonSet would also land on the infra/app nodes, running idle pods
+##      there — nothing outside the postgres nodes uses this StorageClass.
+##   3. Bumps the hostpath container image from the upstream v1.15.0 (which ships
+##      BusyBox tar, lacking --ignore-failed-read) to the driver version, whose
+##      image installs GNU tar. Required by the ignoreFailedRead VolumeSnapshotClass
+##      parameter used for online snapshots of a running PostgreSQL instance.
+##
+## ${CSI_SNAPSHOTTER_IMAGE} and ${CSI_DRIVER_HOST_PATH_VERSION} are rendered by
+## scripts/csi-hostpath.sh before applying.
+##
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/postgres: ""
+      tolerations:
+        - key: node-role.kubernetes.io/postgres
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: csi-snapshotter
+          image: ${CSI_SNAPSHOTTER_IMAGE}
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --node-deployment=true
+            - --leader-election=false
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        # Override the upstream hostpath image: v1.15.0 has BusyBox tar (no
+        # --ignore-failed-read); the driver-version image ships GNU tar.
+        - name: hostpath
+          image: registry.k8s.io/sig-storage/hostpathplugin:${CSI_DRIVER_HOST_PATH_VERSION}

--- a/k8s/csi-hostpath/csi-hostpath-rbac.yaml
+++ b/k8s/csi-hostpath/csi-hostpath-rbac.yaml
@@ -1,0 +1,59 @@
+##
+## The csi-snapshotter sidecar shares the pod's `csi-provisioner` ServiceAccount
+## (a pod cannot give individual containers distinct ServiceAccounts). The
+## upstream external-snapshotter RBAC binds the `external-snapshotter-runner`
+## ClusterRole to a separate `csi-snapshotter` ServiceAccount, so we add a
+## binding to `csi-provisioner` here. The ClusterRole itself is created by
+## applying the upstream external-snapshotter RBAC (see scripts/csi-hostpath.sh).
+##
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-hostpath-provisioner-snapshotter-role
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: external-snapshotter-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+##
+## Distributed snapshotting needs the snapshot-controller to watch Nodes (to route
+## each snapshot to the node that owns the volume). Upstream ships this rule
+## commented out in rbac-snapshot-controller.yaml — since we apply that file
+## verbatim from a URL, we grant the permission to the snapshot-controller
+## ServiceAccount here instead.
+##
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-hostpath-snapshot-controller-nodes
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-hostpath-snapshot-controller-nodes
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-hostpath-snapshot-controller-nodes
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/csi-hostpath/csi-hostpath-snapshotclass.yaml
+++ b/k8s/csi-hostpath/csi-hostpath-snapshotclass.yaml
@@ -1,0 +1,20 @@
+##
+## Default VolumeSnapshotClass for the hostpath driver.
+##
+## `ignoreFailedRead: "true"` lets snapshots of a running PostgreSQL instance
+## succeed even if some files cannot be read, matching the CloudNativePG
+## end-to-end test configuration.
+##
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-hostpath-snapclass
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: hostpath.csi.k8s.io
+deletionPolicy: Delete
+parameters:
+  ignoreFailedRead: "true"

--- a/k8s/csi-hostpath/snapshot-controller-patch.yaml
+++ b/k8s/csi-hostpath/snapshot-controller-patch.yaml
@@ -1,0 +1,18 @@
+##
+## Strategic-merge patch applied to the upstream snapshot-controller Deployment
+## (kubernetes-csi/external-snapshotter). Adds --enable-distributed-snapshotting,
+## which tells the controller that a csi-snapshotter sidecar runs on each node
+## (see csi-hostpath-plugin-patch.yaml) and routes snapshot operations to the node
+## that owns each volume.
+##
+## `args` has no strategic-merge key, so the full list is restated here.
+##
+spec:
+  template:
+    spec:
+      containers:
+        - name: snapshot-controller
+          args:
+            - "--v=5"
+            - "--leader-election=true"
+            - "--enable-distributed-snapshotting=true"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -80,4 +80,22 @@ BARMAN_CLOUD_PLUGIN_VERSION="${BARMAN_CLOUD_PLUGIN_VERSION:-v0.13.0}"
 # renovate: datasource=github-releases depName=grafana/grafana-operator
 GRAFANA_OPERATOR_VERSION="${GRAFANA_OPERATOR_VERSION:-v5.24.0}"
 
+# CSI hostpath driver + volume snapshot support (distributed deployment).
+# scripts/csi-hostpath.sh applies the upstream kubernetes-csi manifests straight
+# from these pinned versions and layers only small local deltas on top (see
+# k8s/csi-hostpath/), so each PostgreSQL instance gets node-local storage with
+# per-node snapshot support.
+# renovate: datasource=github-releases depName=kubernetes-csi/csi-driver-host-path
+CSI_DRIVER_HOST_PATH_VERSION="${CSI_DRIVER_HOST_PATH_VERSION:-v1.17.0}"
+# renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+EXTERNAL_SNAPSHOTTER_VERSION="${EXTERNAL_SNAPSHOTTER_VERSION:-v8.4.0}"
+# renovate: datasource=github-releases depName=kubernetes-csi/external-provisioner
+EXTERNAL_PROVISIONER_VERSION="${EXTERNAL_PROVISIONER_VERSION:-v6.1.0}"
+# csi-snapshotter sidecar added to the node plugin for distributed snapshotting.
+# renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-snapshotter
+CSI_SNAPSHOTTER_IMAGE="${CSI_SNAPSHOTTER_IMAGE:-registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0}"
+# StorageClass exposed by the driver; also the class PostgreSQL clusters use by
+# default (see demo/templates/cluster.yaml and demo/setup.sh STORAGE_CLASS).
+CSI_STORAGE_CLASS="${CSI_STORAGE_CLASS:-csi-hostpath-fast}"
+
 source "${REPO_ROOT}/scripts/funcs_regions.sh"

--- a/scripts/csi-hostpath.sh
+++ b/scripts/csi-hostpath.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+##
+## Copyright © contributors to CloudNativePG, established as
+## CloudNativePG a Series of LF Projects, LLC.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+
+#
+# Deploys the CSI hostpath driver with volume snapshot support to the current
+# kubectl context, using the distributed (per-node) deployment so that each
+# PostgreSQL instance gets node-local storage and per-node snapshot support.
+#
+# To keep maintenance low, the upstream kubernetes-csi manifests are applied
+# straight from their pinned versions (see common.sh) and only small local deltas
+# are layered on top:
+#
+#   - k8s/csi-hostpath/csi-hostpath-plugin-patch.yaml   adds a csi-snapshotter
+#       sidecar (distributed snapshotting) + the postgres taint toleration to the
+#       upstream node-plugin DaemonSet
+#   - k8s/csi-hostpath/snapshot-controller-patch.yaml   enables distributed
+#       snapshotting on the upstream snapshot-controller
+#   - k8s/csi-hostpath/csi-hostpath-rbac.yaml           binds external-snapshotter-runner
+#       to the shared csi-provisioner ServiceAccount
+#   - k8s/csi-hostpath/csi-hostpath-snapshotclass.yaml  default VolumeSnapshotClass
+#       (upstream's distributed deployment ships none)
+#
+# The upstream distributed deployment runs a DaemonSet on every eligible node and
+# provisions volumes locally (--node-deployment=true) with a WaitForFirstConsumer
+# StorageClass, so PostgreSQL keeps its required pod anti-affinity spread while
+# each instance gets node-local storage.
+#
+
+# --- Deploy the CSI hostpath driver + snapshot support ---
+# Expects the caller to have selected the target cluster context. REPO_ROOT and
+# the version variables come from common.sh.
+deploy_csi_host_path() {
+    local csi_base="https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/${CSI_DRIVER_HOST_PATH_VERSION}"
+    local snap_base="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}"
+    local prov_base="https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/${EXTERNAL_PROVISIONER_VERSION}"
+    local dist_base="${csi_base}/deploy/kubernetes-distributed/hostpath"
+    local manifests_dir="${REPO_ROOT}/k8s/csi-hostpath"
+
+    echo "🗄️  Deploying CSI hostpath driver with volume snapshot support..."
+
+    # 1. Volume snapshot CRDs (cluster-scoped) — must exist before our snapshotclass.
+    echo "   - Installing volume snapshot CRDs (external-snapshotter ${EXTERNAL_SNAPSHOTTER_VERSION})"
+    kubectl apply -f "${snap_base}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+    kubectl apply -f "${snap_base}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+    kubectl apply -f "${snap_base}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
+
+    # 2. Upstream RBAC: creates the csi-provisioner ServiceAccount and the
+    #    external-provisioner-runner / external-snapshotter-runner ClusterRoles.
+    #    Upstream hardcodes `namespace: default` for the ServiceAccounts and their
+    #    namespaced Roles/bindings; relocate those to kube-system (client-side
+    #    rewrite, no extra tooling — kubectl fetches the URL, sed moves the ns).
+    echo "   - Installing upstream provisioner and snapshotter RBAC (in kube-system)"
+    kubectl create --dry-run=client -o yaml \
+        -f "${prov_base}/deploy/kubernetes/rbac.yaml" \
+        | sed "s|namespace: default|namespace: kube-system|g" | kubectl apply -f -
+    kubectl create --dry-run=client -o yaml \
+        -f "${snap_base}/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml" \
+        | sed "s|namespace: default|namespace: kube-system|g" | kubectl apply -f -
+    kubectl apply -f "${snap_base}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+
+    # 3. Upstream snapshot-controller, patched to enable distributed snapshotting.
+    echo "   - Deploying the snapshot controller (distributed snapshotting)"
+    kubectl apply -f "${snap_base}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+    kubectl patch deployment snapshot-controller -n kube-system --type=strategic \
+        --patch "$(cat "${manifests_dir}/snapshot-controller-patch.yaml")"
+
+    # 4. Upstream distributed driver: CSIDriver + StorageClass, then the node-plugin
+    #    DaemonSet patched to add the snapshotter sidecar and the postgres toleration.
+    echo "   - Deploying the driver, StorageClass and node plugin (csi-driver-host-path ${CSI_DRIVER_HOST_PATH_VERSION})"
+    kubectl apply -f "${dist_base}/csi-hostpath-driverinfo.yaml"
+    kubectl apply -f "${dist_base}/csi-hostpath-storageclass-fast.yaml"
+    # The upstream DaemonSet declares no namespace; place it in kube-system.
+    kubectl apply -n kube-system -f "${dist_base}/csi-hostpath-plugin.yaml"
+    kubectl patch daemonset csi-hostpathplugin -n kube-system --type=strategic \
+        --patch "$(sed \
+            -e "s|\${CSI_SNAPSHOTTER_IMAGE}|${CSI_SNAPSHOTTER_IMAGE}|g" \
+            -e "s|\${CSI_DRIVER_HOST_PATH_VERSION}|${CSI_DRIVER_HOST_PATH_VERSION}|g" \
+            "${manifests_dir}/csi-hostpath-plugin-patch.yaml")"
+
+    # 5. Our genuinely-local deltas: RBAC binding + default VolumeSnapshotClass.
+    echo "   - Binding snapshotter RBAC and installing the VolumeSnapshotClass"
+    kubectl apply -f "${manifests_dir}/csi-hostpath-rbac.yaml"
+    kubectl apply -f "${manifests_dir}/csi-hostpath-snapshotclass.yaml"
+
+    # 6. Wait for the node plugin and controller to become ready.
+    echo "   ⏳ Waiting for the CSI hostpath plugin to be ready..."
+    kubectl rollout status daemonset/csi-hostpathplugin -n kube-system --timeout=300s
+    kubectl rollout status deployment/snapshot-controller -n kube-system --timeout=300s
+
+    echo "✅ CSI hostpath driver ready (StorageClass '${CSI_STORAGE_CLASS}')."
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,6 +35,11 @@
 
 # Source the common setup script
 source "$(dirname "$0")/common.sh"
+# Provides deploy_csi_host_path()
+source "$(dirname "$0")/csi-hostpath.sh"
+
+# Deploy the CSI hostpath driver + volume snapshot support unless disabled.
+DEPLOY_CSI_HOSTPATH="${DEPLOY_CSI_HOSTPATH:-true}"
 
 echo "✅ Prerequisites met. Using '$CONTAINER_PROVIDER' as the container provider."
 
@@ -107,6 +112,12 @@ for region in "${REGIONS[@]}"; do
     kubectl label node -l postgres.node.kubernetes.io node-role.kubernetes.io/postgres=
     kubectl label node -l infra.node.kubernetes.io node-role.kubernetes.io/infra=
     kubectl label node -l app.node.kubernetes.io node-role.kubernetes.io/app=
+
+    if [ "${DEPLOY_CSI_HOSTPATH}" == "true" ]; then
+        deploy_csi_host_path
+    else
+        echo "⏭️  Skipping CSI hostpath driver deployment (DEPLOY_CSI_HOSTPATH=${DEPLOY_CSI_HOSTPATH})."
+    fi
 
     echo "🌐 Connecting RustFS to the Kind network..."
     $CONTAINER_PROVIDER network connect kind "${RUSTFS_CONTAINER_NAME}"


### PR DESCRIPTION
Deploy the kubernetes-csi hostpath driver to every region from `scripts/setup.sh` (skippable via `DEPLOY_CSI_HOSTPATH=false`), using its distributed deployment so each PostgreSQL instance keeps its required pod anti-affinity spread across the postgres nodes while getting node-local storage with per-node volume snapshot support.

`scripts/csi-hostpath.sh` applies the upstream manifests straight from pinned versions (`CSI_DRIVER_HOST_PATH_VERSION`, `EXTERNAL_SNAPSHOTTER_VERSION`, `EXTERNAL_PROVISIONER_VERSION` in `scripts/common.sh`) and layers only small local deltas from `k8s/csi-hostpath/`: a `csi-snapshotter` sidecar plus the postgres taint toleration on the node plugin, distributed snapshotting on the snapshot-controller, an RBAC binding, and a default `VolumeSnapshotClass`.

The demo clusters use the `csi-hostpath-fast` StorageClass by default (`STORAGE_CLASS` in `demo/setup.sh`; set to "" for the cluster default) and, when on that class, gain a `spec.backup.volumeSnapshot` block referencing `csi-hostpath-snapclass` (`VOLUME_SNAPSHOT_CLASS`), while WAL archiving stays on the object store for point-in-time recovery.

Closes #80

Assisted-by: Claude